### PR TITLE
feat(automation): daily cron job for data ingestion at 10:00 UTC

### DIFF
--- a/scripts/install_cron.sh
+++ b/scripts/install_cron.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Installs the RDD daily ingest cron entry at 10:00 UTC Mon–Fri.
+# Idempotent — safe to run multiple times; replaces any existing rdd-managed entry.
+# TZ=UTC is written into the crontab so the 10AM trigger is timezone-independent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+RUNNER="$SCRIPT_DIR/run_daily_ingest.sh"
+LOG_DIR="$PROJECT_ROOT/logs"
+LOG_FILE="$LOG_DIR/cron.log"
+MARKER="# rdd-daily-ingest"
+
+mkdir -p "$LOG_DIR"
+
+CURRENT=$(crontab -l 2>/dev/null || true)
+
+CLEANED=$(echo "$CURRENT" | grep -v "$MARKER" | grep -v "run_daily_ingest" || true)
+
+NEW_ENTRY="TZ=UTC
+0 10 * * 1-5 /bin/bash $RUNNER >> $LOG_FILE 2>&1 $MARKER"
+
+printf '%s\n%s\n' "$CLEANED" "$NEW_ENTRY" | grep -v '^$' | crontab -
+
+echo "Installed. Current crontab:"
+crontab -l

--- a/scripts/logrotate.conf
+++ b/scripts/logrotate.conf
@@ -1,0 +1,13 @@
+# Log rotation config for RDD daily ingest logs.
+# To activate on macOS, add a weekly cron entry:
+#   0 9 * * 0 /usr/local/bin/logrotate /path/to/scripts/logrotate.conf --state /tmp/rdd-logrotate.status
+
+/path/to/logs/daily_ingest.log
+/path/to/logs/cron.log {
+    weekly
+    rotate 4
+    compress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/scripts/run_daily_ingest.sh
+++ b/scripts/run_daily_ingest.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Runs the RDD data ingestion pipelines sequentially.
+# Safe to call from cron — sets PATH explicitly and sources .env from the project root.
+#
+# Usage:
+#   ./run_daily_ingest.sh            # normal run
+#   ./run_daily_ingest.sh --dry-run  # print commands without executing
+#
+# Log rotation (optional):
+#   Add to crontab: 0 9 * * 0 /usr/local/bin/logrotate /path/to/scripts/logrotate.conf
+#   Or use macOS launchd with a weekly StartCalendarInterval trigger.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+LOG_DIR="$PROJECT_ROOT/logs"
+LOG_FILE="$LOG_DIR/daily_ingest.log"
+DRY_RUN=false
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+mkdir -p "$LOG_DIR"
+
+ts() { date -u "+%Y-%m-%dT%H:%M:%SZ"; }
+
+log() {
+  echo "[$(ts)] $*" | tee -a "$LOG_FILE"
+}
+
+run_pipeline() {
+  local pipeline="$1"
+
+  if $DRY_RUN; then
+    echo "[DRY-RUN] uv run kedro run --pipeline $pipeline"
+    return 0
+  fi
+
+  local registered
+  registered=$(cd "$PROJECT_ROOT" && uv run kedro pipeline list 2>/dev/null || true)
+
+  if ! echo "$registered" | grep -qx "$pipeline"; then
+    log "[SKIP] Pipeline '$pipeline' not registered — skipping"
+    return 0
+  fi
+
+  log "[START] $pipeline"
+  (cd "$PROJECT_ROOT" && uv run kedro run --pipeline "$pipeline") >> "$LOG_FILE" 2>&1
+  log "[OK]    $pipeline"
+}
+
+main() {
+  if [[ -f "$PROJECT_ROOT/.env" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/.env"
+    set +a
+  fi
+
+  log "=== daily ingest start ==="
+
+  run_pipeline data_ingestion
+  run_pipeline finnhub_news
+  run_pipeline newsapi_news
+
+  log "=== [DONE] ==="
+}
+
+main "$@"

--- a/scripts/uninstall_cron.sh
+++ b/scripts/uninstall_cron.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Removes the RDD daily ingest cron entry. Does not touch other crontab entries.
+
+set -euo pipefail
+
+MARKER="# rdd-daily-ingest"
+
+CURRENT=$(crontab -l 2>/dev/null || true)
+
+if ! echo "$CURRENT" | grep -q "$MARKER"; then
+  echo "No rdd-managed cron entry found — nothing to remove."
+  exit 0
+fi
+
+CLEANED=$(echo "$CURRENT" | grep -v "$MARKER" | grep -v "run_daily_ingest" | grep -v "^TZ=UTC$" || true)
+
+if [[ -z "$CLEANED" ]]; then
+  crontab -r
+else
+  echo "$CLEANED" | crontab -
+fi
+
+echo "Removed. Current crontab:"
+crontab -l 2>/dev/null || echo "(empty)"

--- a/tests/scripts/test_run_daily_ingest.py
+++ b/tests/scripts/test_run_daily_ingest.py
@@ -1,0 +1,34 @@
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "run_daily_ingest.sh"
+PIPELINES = ["data_ingestion", "finnhub_news", "newsapi_news"]
+
+
+def test_dry_run_exits_zero():
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT), "--dry-run"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_dry_run_contains_all_pipelines():
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT), "--dry-run"],
+        capture_output=True,
+        text=True,
+    )
+    for pipeline in PIPELINES:
+        assert pipeline in result.stdout, f"Missing pipeline in dry-run output: {pipeline}"
+
+
+def test_dry_run_pipeline_order():
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT), "--dry-run"],
+        capture_output=True,
+        text=True,
+    )
+    positions = [result.stdout.index(p) for p in PIPELINES]
+    assert positions == sorted(positions), "Pipelines not printed in expected order"


### PR DESCRIPTION
## Summary

- Adds a runner script (`scripts/run_daily_ingest.sh`) that sequences the three data ingestion Kedro pipelines (`data_ingestion`, `finnhub_news`, `newsapi_news`), skips any pipeline not yet registered, and supports a `--dry-run` flag
- Adds `scripts/install_cron.sh` — idempotent installer that writes a `TZ=UTC` cron entry firing at `0 10 * * 1-5`, so the 10 AM trigger is stable regardless of the user's travel timezone
- Adds `scripts/uninstall_cron.sh` — removes only the rdd-managed cron entry via a comment marker
- Adds `scripts/logrotate.conf` — weekly rotation, 4 compressed copies
- Adds `tests/scripts/test_run_daily_ingest.py` — three smoke tests validating the `--dry-run` path (exit code, pipeline names present, correct order)

Closes #10

## To activate after merge

```bash
bash scripts/install_cron.sh
```

Verify with `crontab -l` — you should see:
```
TZ=UTC
0 10 * * 1-5 /bin/bash /path/to/scripts/run_daily_ingest.sh >> .../logs/cron.log 2>&1 # rdd-daily-ingest
```

## Test plan

- [ ] `uv run pytest tests/scripts/` passes (dry-run smoke tests)
- [ ] `bash scripts/run_daily_ingest.sh --dry-run` prints three pipeline commands in order and exits 0
- [ ] `bash scripts/install_cron.sh` installs the entry; `crontab -l` shows `TZ=UTC` and `0 10 * * 1-5`
- [ ] `bash scripts/uninstall_cron.sh` removes the entry without touching any other crontab lines
- [ ] Log file appears in `logs/daily_ingest.log` after a real run

🤖 Generated with [Claude Code](https://claude.com/claude-code)