### PR TITLE
chore: configure pre-commit hook suite

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,22 @@
+[mypy]
+python_version = 3.13
+strict = true
+warn_return_any = true
+warn_unused_ignores = true
+no_implicit_reexport = true
+
+# Third-party libraries without bundled stubs
+[mypy-yfinance.*]
+ignore_missing_imports = true
+
+[mypy-finnhub.*]
+ignore_missing_imports = true
+
+[mypy-newsapi.*]
+ignore_missing_imports = true
+
+[mypy-kedro.*]
+ignore_missing_imports = true
+
+[mypy-pandera.*]
+ignore_missing_imports = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,76 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
+repos:
+  # ---------------------------------------------------------------------------
+  # General file hygiene
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+
+  # ---------------------------------------------------------------------------
+  # Python formatting & linting (ruff handles both)
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.7
+    hooks:
+      - id: ruff-format
+      - id: ruff-check
+        args: [--fix]
+
+  # ---------------------------------------------------------------------------
+  # Static type checking
+  # ---------------------------------------------------------------------------
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        language: system
+        entry: uv run mypy
+        types: [python]
+        pass_filenames: false
+        args: [src/]
+
+  # ---------------------------------------------------------------------------
+  # Secret detection
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: [--baseline, .secrets.baseline]
+
+  # ---------------------------------------------------------------------------
+  # Lock file consistency
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.6.14
+    hooks:
+      - id: uv-lock
+
+  # ---------------------------------------------------------------------------
+  # Commit message convention (commit-msg stage)
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.0.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          - feat
+          - fix
+          - chore
+          - docs
+          - style
+          - refactor
+          - perf
+          - test
+          - build
+          - ci
+          - revert

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,133 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "\\.venv"
+      ]
+    }
+  ],
+  "results": {},
+  "generated_at": "2026-04-25T07:25:20Z"
+}


### PR DESCRIPTION
## Summary

Sets up a full pre-commit hook suite across three new files. Hooks run automatically on `git commit`; the conventional-commit check runs on the commit message stage.

| Hook | Stage | Purpose |
|------|-------|---------|
| `trailing-whitespace` + `end-of-file-fixer` | pre-commit | File hygiene |
| `check-yaml` + `check-toml` | pre-commit | Validates `catalog.yml`, `parameters.yml`, `pyproject.toml` |
| `ruff-format` + `ruff-check --fix` | pre-commit | Formatting and linting |
| `mypy` (via `uv run`) | pre-commit | Static type checking against `src/` |
| `detect-secrets` | pre-commit | Blocks accidental commits of API keys / credentials |
| `uv-lock` | pre-commit | Keeps `uv.lock` consistent with `pyproject.toml` |
| `conventional-pre-commit` | commit-msg | Enforces `feat:` / `fix:` / `chore:` etc. message format |

## Files changed

- **`.pre-commit-config.yaml`** — full hook configuration
- **`.mypy.ini`** — strict mypy in `src/`; suppresses `ignore_missing_imports` for third-party libs without stubs (yfinance, finnhub, newsapi, kedro, pandera)
- **`.secrets.baseline`** — empty detect-secrets baseline (repo is clean)

## One-time setup action required

Before `pre-commit install` works, add `mypy` and `types-requests` to the `lint` dependency group in `pyproject.toml`:

```toml
[dependency-groups]
lint = ["pre-commit>=4.0", "ruff>=0.15", "mypy>=1.15", "types-requests>=2.31"]
```

Then install hooks:

```bash
uv sync
uv run pre-commit install        # installs pre-commit + commit-msg hooks
uv run pre-commit run --all-files  # smoke-test against the full repo
```

## Test plan

- [ ] `uv run pre-commit run --all-files` passes on main
- [ ] A commit with a credential-like string is blocked by detect-secrets
- [ ] A commit message like `"add stuff"` is rejected; `"feat: add stuff"` passes
- [ ] A commit touching a `.py` file triggers mypy and reports type errors correctly
- [ ] A malformed `catalog.yml` is caught by `check-yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)