### PR TITLE
fix: ensure conf/local exists before kedro run

### DIFF
--- a/scripts/run_daily_ingest.sh
+++ b/scripts/run_daily_ingest.sh
@@ -25,6 +25,8 @@ if [[ "${1:-}" == "--dry-run" ]]; then
 fi
 
 mkdir -p "$LOG_DIR"
+# OmegaConf globals resolver requires conf/local to exist even when empty.
+mkdir -p "$PROJECT_ROOT/conf/local"
 
 ts() { date -u "+%Y-%m-%dT%H:%M:%SZ"; }
 


### PR DESCRIPTION
## Summary

- `conf/local/` is gitignored but Kedro's `OmegaConfigLoader` requires it to exist at startup
- Without it, globals are never loaded and `${globals:data_dir}` in the catalog raises `InterpolationResolutionError`
- `scripts/run_daily_ingest.sh` now runs `mkdir -p conf/local` before any `kedro run`

Discovered during first live test run of the data ingestion pipeline.

## Test plan

- [ ] Remove `conf/local/` locally, run via the script — pipeline completes without error
- [ ] `bash scripts/run_daily_ingest.sh --dry-run` exits 0
- [ ] `uv run pytest tests/scripts/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)