### PR TITLE
chore: add vulture dead-code detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,19 @@ repos:
         args: [--fix]
 
   # ---------------------------------------------------------------------------
+  # Dead code detection
+  # ---------------------------------------------------------------------------
+  - repo: local
+    hooks:
+      - id: vulture
+        name: vulture (dead code)
+        language: system
+        entry: uv run vulture
+        args: [src/, --min-confidence, "80"]
+        types: [python]
+        pass_filenames: false
+
+  # ---------------------------------------------------------------------------
   # Secret detection
   # ---------------------------------------------------------------------------
   - repo: https://github.com/Yelp/detect-secrets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ required-version = ">=0.10.0"
 default-groups = ["dev"]
 
 [dependency-groups]
-lint = ["pre-commit>=4.0", "ruff>=0.15"]
+lint = ["pre-commit>=4.0", "ruff>=0.15", "vulture>=2.14"]
 test = ["pytest>=9.0", "pytest-cov", "pytest-mock>=3.0", "pytest-socket>=0.7", "hypothesis>=6.0"]
 dev = [
     { include-group = "lint" },

--- a/src/rdd/schemas/ohlcv.py
+++ b/src/rdd/schemas/ohlcv.py
@@ -62,7 +62,7 @@ class OHLCVSchema(DataFrameModel):
         coerce = True
 
     @pa.dataframe_check
-    def high_gte_low(cls, df: pd.DataFrame) -> pd.Series:
+    def high_gte_low(_cls, df: pd.DataFrame) -> pd.Series:
         """High must be >= low wherever both are present."""
         mask = df["high"].notna() & df["low"].notna()
         return (df.loc[mask, "high"] >= df.loc[mask, "low"]).reindex(
@@ -70,7 +70,7 @@ class OHLCVSchema(DataFrameModel):
         )
 
     @pa.dataframe_check
-    def close_within_high_low(cls, df: pd.DataFrame) -> pd.Series:
+    def close_within_high_low(_cls, df: pd.DataFrame) -> pd.Series:
         """Close must fall within [low, high] wherever all three are present."""
         mask = df["close"].notna() & df["high"].notna() & df["low"].notna()
         within = (df.loc[mask, "close"] >= df.loc[mask, "low"]) & (

--- a/uv.lock
+++ b/uv.lock
@@ -1262,10 +1262,12 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-socket" },
     { name = "ruff" },
+    { name = "vulture" },
 ]
 lint = [
     { name = "pre-commit" },
     { name = "ruff" },
+    { name = "vulture" },
 ]
 test = [
     { name = "hypothesis" },
@@ -1295,10 +1297,12 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.0" },
     { name = "pytest-socket", specifier = ">=0.7" },
     { name = "ruff", specifier = ">=0.15" },
+    { name = "vulture", specifier = ">=2.14" },
 ]
 lint = [
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "ruff", specifier = ">=0.15" },
+    { name = "vulture", specifier = ">=2.14" },
 ]
 test = [
     { name = "hypothesis", specifier = ">=6.0" },
@@ -1464,6 +1468,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds [vulture](https://github.com/jendrikseipp/vulture) to the pre-commit hook suite to catch unused functions, classes, and variables before they accumulate.

## Changes

| File | Change |
|------|--------|
| `.pre-commit-config.yaml` | Local vulture hook — scans `src/` at 80% confidence on every commit |
| `pyproject.toml` | `vulture>=2.14` added to `lint` dependency group |
| `src/rdd/schemas/ohlcv.py` | Renamed `cls` → `_cls` in `@pa.dataframe_check` methods |

## Why `_cls` instead of a whitelist

The only false positives vulture found were the `cls` arguments in pandera's `@dataframe_check` methods — pandera requires a first positional argument but never uses it. Prefixing with `_` is the Python convention for intentionally-unused variables and is the minimal, zero-maintenance fix. No whitelist file needed.

## Confidence threshold

`--min-confidence 80` filters out low-confidence guesses (e.g. attributes accessed via `getattr`). Anything at 80%+ is genuinely unused.

## When you need a whitelist

If a future symbol is flagged but is genuinely needed (e.g. called dynamically, exported as a public API), add it to a `whitelist.py` at the repo root and pass it to vulture: `uv run vulture src/ whitelist.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)