### PR TITLE
feat(data): add company_info and company_news ingestion pipelines

### DIFF
--- a/conf/base/catalog/catalog_company_info.yml
+++ b/conf/base/catalog/catalog_company_info.yml
@@ -1,0 +1,26 @@
+# Read-side: existing snapshots fed into the ingest node as lazy loaders.
+# Uses NullablePartitionedDataset so the first run (empty dir) returns {} gracefully.
+raw_company_info_existing:
+  type: rdd.datasets.nullable_partitioned.NullablePartitionedDataset
+  path: ${globals:data_dir}raw/company_info
+  dataset:
+    type: pandas.ParquetDataset
+  filename_suffix: ".parquet"
+  metadata:
+    kedro-viz:
+      layer: raw
+
+# Write-side: merged output saved back to the same path.
+raw_company_info:
+  type: kedro_datasets.partitions.PartitionedDataset
+  path: ${globals:data_dir}raw/company_info
+  dataset:
+    type: pandas.ParquetDataset
+  filename_suffix: ".parquet"
+  metadata:
+    kedro-viz:
+      layer: raw
+    pandera:
+      schema:
+        type: python.model
+        object_path: rdd.schemas.company_info.CompanyInfoSchema

--- a/conf/base/catalog/catalog_company_news.yml
+++ b/conf/base/catalog/catalog_company_news.yml
@@ -1,0 +1,26 @@
+# Read-side: existing stored articles fed into the ingest node as lazy loaders.
+# Uses NullablePartitionedDataset so the first run (empty dir) returns {} gracefully.
+raw_company_news_existing:
+  type: rdd.datasets.nullable_partitioned.NullablePartitionedDataset
+  path: ${globals:data_dir}raw/company_news
+  dataset:
+    type: pandas.ParquetDataset
+  filename_suffix: ".parquet"
+  metadata:
+    kedro-viz:
+      layer: raw
+
+# Write-side: merged output saved back to the same path.
+raw_company_news:
+  type: kedro_datasets.partitions.PartitionedDataset
+  path: ${globals:data_dir}raw/company_news
+  dataset:
+    type: pandas.ParquetDataset
+  filename_suffix: ".parquet"
+  metadata:
+    kedro-viz:
+      layer: raw
+    pandera:
+      schema:
+        type: python.model
+        object_path: rdd.schemas.company_news.CompanyNewsSchema

--- a/conf/base/parameters/params_company_info.yml
+++ b/conf/base/parameters/params_company_info.yml
@@ -1,0 +1,2 @@
+company_info:
+  refresh_days: 7  # re-fetch a ticker's snapshot if it is older than this many days

--- a/conf/base/parameters/params_company_news.yml
+++ b/conf/base/parameters/params_company_news.yml
@@ -1,0 +1,2 @@
+company_news:
+  start_date: "2023-01-01"  # initial fetch window start for tickers with no stored articles

--- a/src/rdd/pipeline_registry.py
+++ b/src/rdd/pipeline_registry.py
@@ -2,12 +2,19 @@
 
 from kedro.pipeline import Pipeline
 
+from rdd.pipelines.company_info.pipeline import create_pipeline as company_info
+from rdd.pipelines.company_news.pipeline import create_pipeline as company_news
 from rdd.pipelines.data_ingestion.pipeline import create_pipeline as data_ingestion
 
 
 def register_pipelines() -> dict[str, Pipeline]:
     """Register all project pipelines."""
+    di = data_ingestion()
+    ci = company_info()
+    cn = company_news()
     return {
-        "__default__": data_ingestion(),
-        "data_ingestion": data_ingestion(),
+        "__default__": di + ci + cn,
+        "data_ingestion": di,
+        "company_info": ci,
+        "company_news": cn,
     }

--- a/src/rdd/pipelines/company_info/__init__.py
+++ b/src/rdd/pipelines/company_info/__init__.py
@@ -1,0 +1,1 @@
+"""Company information ingestion pipeline."""

--- a/src/rdd/pipelines/company_info/nodes.py
+++ b/src/rdd/pipelines/company_info/nodes.py
@@ -1,0 +1,97 @@
+"""Nodes for the company information ingestion pipeline."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import pandas as pd
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+_INFO_FIELDS: dict[str, str] = {
+    "longName": "name",
+    "sector": "sector",
+    "industry": "industry",
+    "marketCap": "market_cap",
+    "fullTimeEmployees": "employees",
+    "country": "country",
+    "currency": "currency",
+    "exchange": "exchange",
+}
+
+
+def _extract_info(ticker: str, info: dict[str, Any]) -> dict[str, Any]:
+    row: dict[str, Any] = {"ticker": ticker}
+    for src, dst in _INFO_FIELDS.items():
+        row[dst] = info.get(src)
+    row["fetched_at"] = pd.Timestamp.now("UTC").tz_convert(None).floor("s")
+    return row
+
+
+def ingest_company_info(
+    ticker_universe: list[str],
+    existing_company_info: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> dict[str, pd.DataFrame]:
+    """Fetch company metadata from yfinance and persist per-ticker snapshots.
+
+    Skips tickers whose existing snapshot is fresher than ``params.refresh_days``
+    to avoid unnecessary API calls.  Failed fetches are logged and skipped so a
+    single bad ticker does not abort the whole run.
+
+    Args:
+        ticker_universe: Sorted list of ticker symbols to process.
+        existing_company_info: Mapping of ticker (lowercase) → lazy loader from
+            Kedro's ``PartitionedDataset``.  Call ``loader()`` to materialise.
+        params: ``company_info`` parameter block from ``params_company_info.yml``.
+
+    Returns:
+        Mapping of ticker (lowercase) → single-row DataFrame for the
+        ``PartitionedDataset`` to persist.
+    """
+    refresh_days = int(params["refresh_days"])
+    cutoff = pd.Timestamp.now("UTC").tz_convert(None).tz_localize(None) - pd.Timedelta(
+        days=refresh_days
+    )
+
+    result: dict[str, pd.DataFrame] = {}
+    stale: list[str] = []
+
+    for ticker in ticker_universe:
+        partition_key = ticker.lower()
+        if partition_key in existing_company_info:
+            try:
+                df = existing_company_info[partition_key]()
+                if not df.empty and "fetched_at" in df.columns:
+                    last_fetch = pd.Timestamp(df["fetched_at"].iloc[0])
+                    if last_fetch >= cutoff:
+                        result[partition_key] = df
+                        continue
+            except Exception:
+                logger.warning(
+                    "Could not load existing snapshot for %s — will re-fetch.", ticker
+                )
+        stale.append(ticker)
+
+    logger.info(
+        "%d tickers up to date, %d to fetch (refresh_days=%d).",
+        len(result),
+        len(stale),
+        refresh_days,
+    )
+
+    for ticker in stale:
+        try:
+            info = yf.Ticker(ticker).info
+            row = _extract_info(ticker, info)
+            result[ticker.lower()] = pd.DataFrame([row])
+        except Exception:
+            logger.warning(
+                "Failed to fetch info for %s — skipping.", ticker, exc_info=True
+            )
+
+    logger.info("Company info ingestion complete. %d tickers written.", len(result))
+    return result

--- a/src/rdd/pipelines/company_info/pipeline.py
+++ b/src/rdd/pipelines/company_info/pipeline.py
@@ -1,0 +1,23 @@
+"""Company information ingestion pipeline — fetches metadata snapshots from yfinance."""
+
+from kedro.pipeline import Pipeline, node
+
+from rdd.pipelines.company_info.nodes import ingest_company_info
+
+
+def create_pipeline(**_kwargs) -> Pipeline:
+    """Create the company info ingestion pipeline."""
+    return Pipeline(
+        nodes=[
+            node(
+                func=ingest_company_info,
+                inputs=[
+                    "ticker_universe",
+                    "raw_company_info_existing",
+                    "params:company_info",
+                ],
+                outputs="raw_company_info",
+                name="ingest_company_info",
+            ),
+        ]
+    )

--- a/src/rdd/pipelines/company_news/__init__.py
+++ b/src/rdd/pipelines/company_news/__init__.py
@@ -1,0 +1,1 @@
+"""Company news ingestion pipeline (Finnhub)."""

--- a/src/rdd/pipelines/company_news/nodes.py
+++ b/src/rdd/pipelines/company_news/nodes.py
@@ -1,0 +1,154 @@
+"""Nodes for the company news ingestion pipeline (Finnhub)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from typing import Any
+
+import finnhub
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_DATE_FMT = "%Y-%m-%d"
+
+
+def _make_client() -> finnhub.Client:
+    api_key = os.environ.get("FINNHUB_API_KEY", "")
+    if not api_key:
+        msg = "FINNHUB_API_KEY environment variable is not set."
+        raise OSError(msg)
+    return finnhub.Client(api_key=api_key)
+
+
+def _articles_to_df(ticker: str, articles: list[dict[str, Any]]) -> pd.DataFrame:
+    rows = []
+    for art in articles:
+        rows.append(
+            {
+                "ticker": ticker,
+                # tz-naive UTC timestamp — consistent with existing partitioned data
+                "published_at": pd.Timestamp(art.get("datetime", 0), unit="s").floor(
+                    "s"
+                ),
+                "headline": art.get("headline"),
+                "summary": art.get("summary"),
+                "source": art.get("source"),
+                "url": art.get("url"),
+                "category": art.get("category"),
+            }
+        )
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "ticker",
+            "published_at",
+            "headline",
+            "summary",
+            "source",
+            "url",
+            "category",
+        ],
+    )
+
+
+def _merge_articles(
+    old_df: pd.DataFrame | None,
+    new_df: pd.DataFrame,
+) -> pd.DataFrame | None:
+    if old_df is not None and not new_df.empty:
+        return (
+            pd.concat([old_df, new_df], ignore_index=True)
+            .drop_duplicates(subset=["ticker", "published_at", "headline"])
+            .sort_values("published_at")
+            .reset_index(drop=True)
+        )
+    if old_df is not None:
+        return old_df
+    if not new_df.empty:
+        return new_df.sort_values("published_at").reset_index(drop=True)
+    return None
+
+
+def ingest_company_news(
+    ticker_universe: list[str],
+    existing_news: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> dict[str, pd.DataFrame]:
+    """Fetch company news from Finnhub and merge with any existing stored articles.
+
+    Determines the effective fetch window per ticker:
+    - First run (no existing partition): fetches from ``params.start_date``.
+    - Subsequent runs: fetches from the day after the latest stored article.
+
+    Requires ``FINNHUB_API_KEY`` to be set in the environment.
+
+    Args:
+        ticker_universe: Sorted list of ticker symbols to process.
+        existing_news: Mapping of ticker (lowercase) → lazy loader from Kedro's
+            ``PartitionedDataset``.  Call ``loader()`` to materialise.
+        params: ``company_news`` parameter block from ``params_company_news.yml``.
+
+    Returns:
+        Mapping of ticker (lowercase) → merged DataFrame for the
+        ``PartitionedDataset`` to persist.
+    """
+    default_start = pd.Timestamp(params["start_date"])
+    end_date = pd.Timestamp.now("UTC").tz_convert(None).normalize()
+
+    client = _make_client()
+
+    existing_data: dict[str, pd.DataFrame] = {}
+    ticker_starts: dict[str, pd.Timestamp] = {}
+
+    for ticker in ticker_universe:
+        partition_key = ticker.lower()
+        if partition_key in existing_news:
+            try:
+                df = existing_news[partition_key]()
+                if not df.empty and "published_at" in df.columns:
+                    existing_data[ticker] = df
+                    ticker_starts[ticker] = pd.Timestamp(
+                        df["published_at"].max()
+                    ) + pd.Timedelta(days=1)
+                    continue
+            except Exception:
+                logger.warning(
+                    "Could not load existing news for %s — will re-fetch.", ticker
+                )
+        ticker_starts[ticker] = default_start
+
+    result: dict[str, pd.DataFrame] = {}
+
+    for ticker in ticker_universe:
+        fetch_start = ticker_starts[ticker]
+
+        if fetch_start >= end_date:
+            if ticker in existing_data:
+                result[ticker.lower()] = existing_data[ticker]
+            continue
+
+        try:
+            articles = client.company_news(
+                ticker,
+                _from=fetch_start.strftime(_DATE_FMT),
+                to=end_date.strftime(_DATE_FMT),
+            )
+        except Exception:
+            logger.warning(
+                "Finnhub request failed for %s — skipping.", ticker, exc_info=True
+            )
+            if ticker in existing_data:
+                result[ticker.lower()] = existing_data[ticker]
+            continue
+
+        new_df = _articles_to_df(ticker, articles)
+        merged = _merge_articles(existing_data.get(ticker), new_df)
+        if merged is not None:
+            result[ticker.lower()] = merged
+        logger.debug("Fetched %d articles for %s.", len(new_df), ticker)
+
+    logger.info("Company news ingestion complete. %d tickers written.", len(result))
+    return result

--- a/src/rdd/pipelines/company_news/pipeline.py
+++ b/src/rdd/pipelines/company_news/pipeline.py
@@ -1,0 +1,23 @@
+"""Company news ingestion pipeline — fetches news articles from Finnhub."""
+
+from kedro.pipeline import Pipeline, node
+
+from rdd.pipelines.company_news.nodes import ingest_company_news
+
+
+def create_pipeline(**_kwargs) -> Pipeline:
+    """Create the company news ingestion pipeline."""
+    return Pipeline(
+        nodes=[
+            node(
+                func=ingest_company_news,
+                inputs=[
+                    "ticker_universe",
+                    "raw_company_news_existing",
+                    "params:company_news",
+                ],
+                outputs="raw_company_news",
+                name="ingest_company_news",
+            ),
+        ]
+    )

--- a/src/rdd/schemas/company_info.py
+++ b/src/rdd/schemas/company_info.py
@@ -1,0 +1,65 @@
+"""Pandera schema for company information snapshots."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pandera.pandas as pa
+from pandera.pandas import DataFrameModel
+from pandera.typing import Series
+
+
+class CompanyInfoSchema(DataFrameModel):
+    """Schema for company metadata snapshots fetched from yfinance.
+
+    One row = one company snapshot for one ticker.
+    Data is point-in-time as of ``fetched_at``; re-fetching overwrites the row.
+    """
+
+    ticker: Series[str] = pa.Field(
+        nullable=False,
+        description="Exchange-listed ticker symbol in yfinance format (e.g. 'AAPL', 'BRK-B').",
+    )
+    name: Series[str] = pa.Field(
+        nullable=True,
+        description="Full legal company name (yfinance ``longName``).",
+    )
+    sector: Series[str] = pa.Field(
+        nullable=True,
+        description="GICS sector (e.g. 'Technology', 'Financials').",
+    )
+    industry: Series[str] = pa.Field(
+        nullable=True,
+        description="GICS industry sub-classification.",
+    )
+    market_cap: Series[float] = pa.Field(
+        nullable=True,
+        ge=0,
+        description="Market capitalisation in the reporting currency.",
+    )
+    employees: Series[float] = pa.Field(
+        nullable=True,
+        ge=0,
+        description="Number of full-time employees (stored as float to allow NaN).",
+    )
+    country: Series[str] = pa.Field(
+        nullable=True,
+        description="Country of incorporation.",
+    )
+    currency: Series[str] = pa.Field(
+        nullable=True,
+        description="Reporting currency code (e.g. 'USD').",
+    )
+    exchange: Series[str] = pa.Field(
+        nullable=True,
+        description="Primary listing exchange (e.g. 'NMS' for NASDAQ).",
+    )
+    fetched_at: Series[pd.Timestamp] = pa.Field(
+        nullable=False,
+        description="Timestamp (UTC, second precision) when this snapshot was fetched.",
+    )
+
+    class Config:
+        """Pandera config."""
+
+        strict = True
+        coerce = True

--- a/src/rdd/schemas/company_news.py
+++ b/src/rdd/schemas/company_news.py
@@ -1,0 +1,51 @@
+"""Pandera schema for company news articles fetched from Finnhub."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pandera.pandas as pa
+from pandera.pandas import DataFrameModel
+from pandera.typing import Series
+
+
+class CompanyNewsSchema(DataFrameModel):
+    """Schema for company news articles stored per ticker.
+
+    One row = one news article for one ticker.
+    Articles are sourced from Finnhub and stored incrementally.
+    """
+
+    ticker: Series[str] = pa.Field(
+        nullable=False,
+        description="Exchange-listed ticker symbol in yfinance format (e.g. 'AAPL', 'BRK-B').",
+    )
+    published_at: Series[pd.Timestamp] = pa.Field(
+        nullable=False,
+        description="Publication timestamp as a timezone-naive UTC timestamp.",
+    )
+    headline: Series[str] = pa.Field(
+        nullable=True,
+        description="Article headline.",
+    )
+    summary: Series[str] = pa.Field(
+        nullable=True,
+        description="Short article summary.",
+    )
+    source: Series[str] = pa.Field(
+        nullable=True,
+        description="News source name (e.g. 'Reuters').",
+    )
+    url: Series[str] = pa.Field(
+        nullable=True,
+        description="Full URL of the original article.",
+    )
+    category: Series[str] = pa.Field(
+        nullable=True,
+        description="Finnhub news category (e.g. 'company news', 'top news').",
+    )
+
+    class Config:
+        """Pandera config."""
+
+        strict = True
+        coerce = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+from rdd.schemas.company_info import CompanyInfoSchema
+from rdd.schemas.company_news import CompanyNewsSchema
 from rdd.schemas.ohlcv import OHLCVSchema
 
 
@@ -36,3 +38,51 @@ def make_ohlcv_df(
 def ohlcv_df() -> pd.DataFrame:
     """Five-row OHLCV DataFrame that satisfies OHLCVSchema (AAPL, 2024-01-02…)."""
     return make_ohlcv_df()
+
+
+def make_company_info_df(
+    ticker: str = "AAPL",
+    fetched_at: str = "2024-01-02",
+) -> pd.DataFrame:
+    """Return a single-row company info DataFrame that satisfies CompanyInfoSchema."""
+    df = CompanyInfoSchema.example(size=1)
+    df["ticker"] = ticker
+    df["name"] = "Apple Inc."
+    df["sector"] = "Technology"
+    df["industry"] = "Consumer Electronics"
+    df["market_cap"] = 3_000_000_000_000.0
+    df["employees"] = 161_000.0
+    df["country"] = "United States"
+    df["currency"] = "USD"
+    df["exchange"] = "NMS"
+    df["fetched_at"] = pd.Timestamp(fetched_at)
+    return df
+
+
+@pytest.fixture
+def company_info_df() -> pd.DataFrame:
+    """Single-row company info DataFrame that satisfies CompanyInfoSchema (AAPL)."""
+    return make_company_info_df()
+
+
+def make_company_news_df(
+    n: int = 3,
+    ticker: str = "AAPL",
+    start: str = "2024-01-02",
+) -> pd.DataFrame:
+    """Return *n* valid company news rows that satisfy CompanyNewsSchema."""
+    df = CompanyNewsSchema.example(size=n)
+    df["ticker"] = ticker
+    df["published_at"] = pd.date_range(start, periods=n, freq="D")
+    df["headline"] = [f"Headline {i}" for i in range(n)]
+    df["summary"] = [f"Summary {i}" for i in range(n)]
+    df["source"] = "Reuters"
+    df["url"] = [f"https://example.com/{i}" for i in range(n)]
+    df["category"] = "company news"
+    return df
+
+
+@pytest.fixture
+def company_news_df() -> pd.DataFrame:
+    """Three-row company news DataFrame that satisfies CompanyNewsSchema (AAPL)."""
+    return make_company_news_df()

--- a/tests/pipelines/company_info/test_nodes.py
+++ b/tests/pipelines/company_info/test_nodes.py
@@ -1,0 +1,140 @@
+"""Unit tests for company_info nodes.
+
+Network is disabled globally via --disable-socket.  All yfinance calls are
+patched with pytest-mock.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from rdd.pipelines.company_info.nodes import _extract_info, ingest_company_info
+
+_SAMPLE_INFO: dict = {
+    "longName": "Apple Inc.",
+    "sector": "Technology",
+    "industry": "Consumer Electronics",
+    "marketCap": 3_000_000_000_000,
+    "fullTimeEmployees": 161_000,
+    "country": "United States",
+    "currency": "USD",
+    "exchange": "NMS",
+}
+
+
+@pytest.fixture
+def base_params() -> dict:
+    return {"refresh_days": 7}
+
+
+class TestExtractInfo:
+    def test_maps_known_fields(self) -> None:
+        row = _extract_info("AAPL", _SAMPLE_INFO)
+
+        assert row["ticker"] == "AAPL"
+        assert row["name"] == "Apple Inc."
+        assert row["sector"] == "Technology"
+        assert row["industry"] == "Consumer Electronics"
+        assert row["market_cap"] == 3_000_000_000_000
+        assert row["employees"] == 161_000
+        assert row["country"] == "United States"
+        assert row["currency"] == "USD"
+        assert row["exchange"] == "NMS"
+        assert isinstance(row["fetched_at"], pd.Timestamp)
+
+    def test_missing_fields_become_none(self) -> None:
+        row = _extract_info("AAPL", {})
+
+        assert row["name"] is None
+        assert row["sector"] is None
+        assert row["market_cap"] is None
+
+
+class TestIngestCompanyInfo:
+    def test_first_run_fetches_all_tickers(self, mocker, base_params) -> None:
+        mock_ticker = MagicMock()
+        mock_ticker.info = _SAMPLE_INFO
+        mocker.patch(
+            "rdd.pipelines.company_info.nodes.yf.Ticker", return_value=mock_ticker
+        )
+
+        result = ingest_company_info(["AAPL", "MSFT"], {}, base_params)
+
+        assert "aapl" in result
+        assert "msft" in result
+        assert len(result["aapl"]) == 1
+        assert result["aapl"]["ticker"].iloc[0] == "AAPL"
+
+    def test_fresh_snapshot_is_not_refetched(
+        self, mocker, base_params, company_info_df
+    ) -> None:
+        ticker = "AAPL"
+        fresh_df = company_info_df.copy()
+        fresh_df["fetched_at"] = pd.Timestamp.now("UTC").tz_convert(None)
+
+        existing: dict[str, Callable[[], pd.DataFrame]] = {
+            ticker.lower(): lambda: fresh_df
+        }
+        yf_spy = mocker.patch("rdd.pipelines.company_info.nodes.yf.Ticker")
+
+        result = ingest_company_info([ticker], existing, base_params)
+
+        yf_spy.assert_not_called()
+        assert ticker.lower() in result
+
+    def test_stale_snapshot_is_refetched(
+        self, mocker, base_params, company_info_df
+    ) -> None:
+        ticker = "AAPL"
+        stale_df = company_info_df.copy()
+        stale_df["fetched_at"] = pd.Timestamp("2000-01-01")
+
+        existing: dict[str, Callable[[], pd.DataFrame]] = {
+            ticker.lower(): lambda: stale_df
+        }
+        mock_ticker = MagicMock()
+        mock_ticker.info = _SAMPLE_INFO
+        mocker.patch(
+            "rdd.pipelines.company_info.nodes.yf.Ticker", return_value=mock_ticker
+        )
+
+        result = ingest_company_info([ticker], existing, base_params)
+
+        assert result["aapl"]["sector"].iloc[0] == "Technology"
+
+    def test_failed_fetch_is_skipped(self, mocker, base_params) -> None:
+        mocker.patch(
+            "rdd.pipelines.company_info.nodes.yf.Ticker",
+            side_effect=RuntimeError("API error"),
+        )
+
+        result = ingest_company_info(["AAPL"], {}, base_params)
+
+        assert result == {}
+
+    def test_output_contains_expected_columns(self, mocker, base_params) -> None:
+        mock_ticker = MagicMock()
+        mock_ticker.info = _SAMPLE_INFO
+        mocker.patch(
+            "rdd.pipelines.company_info.nodes.yf.Ticker", return_value=mock_ticker
+        )
+
+        result = ingest_company_info(["AAPL"], {}, base_params)
+
+        expected = {
+            "ticker",
+            "name",
+            "sector",
+            "industry",
+            "market_cap",
+            "employees",
+            "country",
+            "currency",
+            "exchange",
+            "fetched_at",
+        }
+        assert expected.issubset(result["aapl"].columns)

--- a/tests/pipelines/company_info/test_pipeline.py
+++ b/tests/pipelines/company_info/test_pipeline.py
@@ -1,0 +1,110 @@
+"""Integration tests for the company_info pipeline.
+
+Runs the pipeline end-to-end via SequentialRunner with a fully in-memory
+DataCatalog.  All yfinance calls are mocked at the module boundary.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from kedro.io import DataCatalog, MemoryDataset
+from kedro.runner import SequentialRunner
+
+from rdd.pipelines.company_info.pipeline import create_pipeline
+
+_SAMPLE_INFO: dict = {
+    "longName": "Apple Inc.",
+    "sector": "Technology",
+    "industry": "Consumer Electronics",
+    "marketCap": 3_000_000_000_000,
+    "fullTimeEmployees": 161_000,
+    "country": "United States",
+    "currency": "USD",
+    "exchange": "NMS",
+}
+
+
+@pytest.fixture
+def pipeline():
+    return create_pipeline()
+
+
+@pytest.fixture
+def params():
+    return {"refresh_days": 7}
+
+
+@pytest.fixture
+def in_memory_catalog(params):
+    return DataCatalog(
+        {
+            "ticker_universe": MemoryDataset(data=["AAPL", "MSFT"]),
+            "raw_company_info_existing": MemoryDataset(data={}),
+            "raw_company_info": MemoryDataset(),
+            "params:company_info": MemoryDataset(data=params),
+        }
+    )
+
+
+def test_pipeline_runs_successfully(mocker, pipeline, in_memory_catalog) -> None:
+    mock_ticker = MagicMock()
+    mock_ticker.info = _SAMPLE_INFO
+    mocker.patch("rdd.pipelines.company_info.nodes.yf.Ticker", return_value=mock_ticker)
+
+    SequentialRunner().run(pipeline, in_memory_catalog)
+
+    result = in_memory_catalog.load("raw_company_info")
+    assert isinstance(result, dict)
+    assert len(result) > 0
+
+
+def test_pipeline_output_schema(mocker, pipeline, in_memory_catalog) -> None:
+    mock_ticker = MagicMock()
+    mock_ticker.info = _SAMPLE_INFO
+    mocker.patch("rdd.pipelines.company_info.nodes.yf.Ticker", return_value=mock_ticker)
+
+    SequentialRunner().run(pipeline, in_memory_catalog)
+
+    result = in_memory_catalog.load("raw_company_info")
+    expected_cols = {
+        "ticker",
+        "name",
+        "sector",
+        "industry",
+        "market_cap",
+        "employees",
+        "country",
+        "currency",
+        "exchange",
+        "fetched_at",
+    }
+    for key, df in result.items():
+        assert expected_cols.issubset(df.columns), f"{key}: missing columns"
+        assert not df.empty, f"{key}: empty DataFrame"
+
+
+def test_pipeline_skips_fresh_snapshots(
+    mocker, pipeline, params, company_info_df
+) -> None:
+    ticker = "AAPL"
+    fresh_df = company_info_df.copy()
+    fresh_df["fetched_at"] = pd.Timestamp.now("UTC").tz_convert(None)
+
+    catalog = DataCatalog(
+        {
+            "ticker_universe": MemoryDataset(data=[ticker]),
+            "raw_company_info_existing": MemoryDataset(
+                data={ticker.lower(): lambda: fresh_df}
+            ),
+            "raw_company_info": MemoryDataset(),
+            "params:company_info": MemoryDataset(data=params),
+        }
+    )
+    yf_spy = mocker.patch("rdd.pipelines.company_info.nodes.yf.Ticker")
+
+    SequentialRunner().run(pipeline, catalog)
+
+    yf_spy.assert_not_called()

--- a/tests/pipelines/company_news/test_nodes.py
+++ b/tests/pipelines/company_news/test_nodes.py
@@ -1,0 +1,208 @@
+"""Unit tests for company_news nodes.
+
+Network is disabled globally via --disable-socket.  All Finnhub calls are
+patched with pytest-mock.  FINNHUB_API_KEY is injected via monkeypatch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pandas as pd
+import pytest
+
+from rdd.pipelines.company_news.nodes import _articles_to_df, ingest_company_news
+
+
+def _make_articles(ticker: str, n: int = 3, base_ts: int | None = None) -> list[dict]:
+    if base_ts is None:
+        base_ts = int(pd.Timestamp("2024-01-02").timestamp())
+    return [
+        {
+            "datetime": base_ts + i * 86_400,
+            "headline": f"Headline {i}",
+            "summary": f"Summary {i}",
+            "source": "Reuters",
+            "url": f"https://example.com/{ticker}/{i}",
+            "category": "company news",
+        }
+        for i in range(n)
+    ]
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+
+
+@pytest.fixture
+def base_params() -> dict:
+    return {"start_date": "2023-01-01"}
+
+
+class TestArticlesToDf:
+    def test_returns_expected_columns(self) -> None:
+        articles = _make_articles("AAPL", n=2)
+        df = _articles_to_df("AAPL", articles)
+
+        assert set(df.columns) == {
+            "ticker",
+            "published_at",
+            "headline",
+            "summary",
+            "source",
+            "url",
+            "category",
+        }
+        assert len(df) == 2
+        assert df["ticker"].iloc[0] == "AAPL"
+
+    def test_empty_articles_returns_empty_df(self) -> None:
+        df = _articles_to_df("AAPL", [])
+        assert df.empty
+        assert "ticker" in df.columns
+
+    def test_unix_timestamp_converted_to_timestamp(self) -> None:
+        ts = int(pd.Timestamp("2024-06-01").timestamp())
+        articles = [
+            {
+                "datetime": ts,
+                "headline": "h",
+                "summary": "s",
+                "source": "s",
+                "url": "u",
+                "category": "c",
+            }
+        ]
+        df = _articles_to_df("AAPL", articles)
+        assert isinstance(df["published_at"].iloc[0], pd.Timestamp)
+
+
+class TestIngestCompanyNews:
+    def test_first_run_fetches_articles(self, mocker, base_params) -> None:
+        articles = _make_articles("AAPL", n=3)
+        mock_client = mocker.MagicMock()
+        mock_client.company_news.return_value = articles
+        mocker.patch(
+            "rdd.pipelines.company_news.nodes.finnhub.Client", return_value=mock_client
+        )
+
+        result = ingest_company_news(["AAPL"], {}, base_params)
+
+        assert "aapl" in result
+        assert len(result["aapl"]) == 3
+
+    def test_incremental_fetches_from_last_date(
+        self, mocker, base_params, company_news_df
+    ) -> None:
+        ticker = "AAPL"
+        existing_df = company_news_df.copy()
+        existing_df["ticker"] = ticker
+        last_date = pd.Timestamp(existing_df["published_at"].max())
+
+        existing: dict[str, Callable[[], pd.DataFrame]] = {
+            ticker.lower(): lambda: existing_df
+        }
+
+        new_ts = int((last_date + pd.Timedelta(days=2)).timestamp())
+        new_articles = _make_articles(ticker, n=2, base_ts=new_ts)
+        mock_client = mocker.MagicMock()
+        mock_client.company_news.return_value = new_articles
+        mocker.patch(
+            "rdd.pipelines.company_news.nodes.finnhub.Client", return_value=mock_client
+        )
+
+        result = ingest_company_news([ticker], existing, base_params)
+
+        call_kwargs = mock_client.company_news.call_args
+        fetch_from = pd.Timestamp(call_kwargs[1]["_from"])
+        assert fetch_from > last_date
+
+        assert len(result[ticker.lower()]) > len(existing_df)
+
+    def test_up_to_date_ticker_skips_api_call(
+        self, mocker, base_params, company_news_df
+    ) -> None:
+        ticker = "AAPL"
+        fresh_df = company_news_df.copy()
+        fresh_df["ticker"] = ticker
+        fresh_df["published_at"] = pd.date_range(
+            end=pd.Timestamp.now("UTC").tz_convert(None),
+            periods=len(fresh_df),
+            freq="D",
+        )
+
+        existing: dict[str, Callable[[], pd.DataFrame]] = {
+            ticker.lower(): lambda: fresh_df
+        }
+        mock_client = mocker.MagicMock()
+        mocker.patch(
+            "rdd.pipelines.company_news.nodes.finnhub.Client", return_value=mock_client
+        )
+
+        ingest_company_news([ticker], existing, base_params)
+
+        mock_client.company_news.assert_not_called()
+
+    def test_failed_api_call_is_skipped(self, mocker, base_params) -> None:
+        mock_client = mocker.MagicMock()
+        mock_client.company_news.side_effect = RuntimeError("API error")
+        mocker.patch(
+            "rdd.pipelines.company_news.nodes.finnhub.Client", return_value=mock_client
+        )
+
+        result = ingest_company_news(["AAPL"], {}, base_params)
+
+        assert result == {}
+
+    def test_existing_data_preserved_on_api_failure(
+        self, mocker, base_params, company_news_df
+    ) -> None:
+        ticker = "AAPL"
+        existing_df = company_news_df.copy()
+        existing_df["ticker"] = ticker
+
+        existing: dict[str, Callable[[], pd.DataFrame]] = {
+            ticker.lower(): lambda: existing_df
+        }
+        mock_client = mocker.MagicMock()
+        mock_client.company_news.side_effect = RuntimeError("API error")
+        mocker.patch(
+            "rdd.pipelines.company_news.nodes.finnhub.Client", return_value=mock_client
+        )
+
+        result = ingest_company_news([ticker], existing, base_params)
+
+        assert ticker.lower() in result
+        assert len(result[ticker.lower()]) == len(existing_df)
+
+    def test_deduplication_on_merge(self, mocker, base_params, company_news_df) -> None:
+        ticker = "AAPL"
+        existing_df = company_news_df.copy()
+        existing_df["ticker"] = ticker
+
+        existing: dict[str, Callable[[], pd.DataFrame]] = {
+            ticker.lower(): lambda: existing_df
+        }
+
+        # Return the same articles as existing — they should be deduplicated
+        same_ts = int(existing_df["published_at"].iloc[0].timestamp())
+        duplicate_articles = [
+            {
+                "datetime": same_ts,
+                "headline": existing_df["headline"].iloc[0],
+                "summary": "x",
+                "source": "x",
+                "url": "x",
+                "category": "x",
+            }
+        ]
+        mock_client = mocker.MagicMock()
+        mock_client.company_news.return_value = duplicate_articles
+        mocker.patch(
+            "rdd.pipelines.company_news.nodes.finnhub.Client", return_value=mock_client
+        )
+
+        result = ingest_company_news([ticker], existing, base_params)
+
+        assert len(result[ticker.lower()]) == len(existing_df)

--- a/tests/pipelines/company_news/test_pipeline.py
+++ b/tests/pipelines/company_news/test_pipeline.py
@@ -1,0 +1,141 @@
+"""Integration tests for the company_news pipeline.
+
+Runs the pipeline end-to-end via SequentialRunner with a fully in-memory
+DataCatalog.  All Finnhub calls are mocked at the module boundary.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from kedro.io import DataCatalog, MemoryDataset
+from kedro.runner import SequentialRunner
+
+from rdd.pipelines.company_news.pipeline import create_pipeline
+
+
+def _make_articles(ticker: str, n: int = 3) -> list[dict]:
+    base_ts = int(pd.Timestamp("2024-01-02").timestamp())
+    return [
+        {
+            "datetime": base_ts + i * 86_400,
+            "headline": f"Headline {i}",
+            "summary": f"Summary {i}",
+            "source": "Reuters",
+            "url": f"https://example.com/{i}",
+            "category": "company news",
+        }
+        for i in range(n)
+    ]
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("FINNHUB_API_KEY", "test-key")
+
+
+@pytest.fixture
+def pipeline():
+    return create_pipeline()
+
+
+@pytest.fixture
+def params():
+    return {"start_date": "2023-01-01"}
+
+
+@pytest.fixture
+def in_memory_catalog(params):
+    return DataCatalog(
+        {
+            "ticker_universe": MemoryDataset(data=["AAPL", "MSFT"]),
+            "raw_company_news_existing": MemoryDataset(data={}),
+            "raw_company_news": MemoryDataset(),
+            "params:company_news": MemoryDataset(data=params),
+        }
+    )
+
+
+def test_pipeline_runs_successfully(mocker, pipeline, in_memory_catalog) -> None:
+    mock_client = mocker.MagicMock()
+    mock_client.company_news.side_effect = lambda t, **_: _make_articles(t)
+    mocker.patch(
+        "rdd.pipelines.company_news.nodes.finnhub.Client", return_value=mock_client
+    )
+
+    SequentialRunner().run(pipeline, in_memory_catalog)
+
+    result = in_memory_catalog.load("raw_company_news")
+    assert isinstance(result, dict)
+    assert "aapl" in result
+    assert "msft" in result
+
+
+def test_pipeline_output_schema(mocker, pipeline, in_memory_catalog) -> None:
+    mock_client = mocker.MagicMock()
+    mock_client.company_news.side_effect = lambda t, **_: _make_articles(t)
+    mocker.patch(
+        "rdd.pipelines.company_news.nodes.finnhub.Client", return_value=mock_client
+    )
+
+    SequentialRunner().run(pipeline, in_memory_catalog)
+
+    result = in_memory_catalog.load("raw_company_news")
+    expected_cols = {
+        "ticker",
+        "published_at",
+        "headline",
+        "summary",
+        "source",
+        "url",
+        "category",
+    }
+    for key, df in result.items():
+        assert expected_cols.issubset(df.columns), f"{key}: missing columns"
+        assert not df.empty, f"{key}: empty DataFrame"
+
+
+def test_pipeline_with_existing_data_does_incremental_fetch(
+    mocker, pipeline, params, company_news_df
+) -> None:
+    ticker = "AAPL"
+    existing_df = company_news_df.copy()
+    existing_df["ticker"] = ticker
+    last_date = pd.Timestamp(existing_df["published_at"].max())
+
+    catalog = DataCatalog(
+        {
+            "ticker_universe": MemoryDataset(data=[ticker]),
+            "raw_company_news_existing": MemoryDataset(
+                data={ticker.lower(): lambda: existing_df}
+            ),
+            "raw_company_news": MemoryDataset(),
+            "params:company_news": MemoryDataset(data=params),
+        }
+    )
+
+    new_ts = int((last_date + pd.Timedelta(days=2)).timestamp())
+    new_articles = [
+        {
+            "datetime": new_ts + i * 86_400,
+            "headline": f"New {i}",
+            "summary": "s",
+            "source": "AP",
+            "url": "u",
+            "category": "c",
+        }
+        for i in range(2)
+    ]
+    mock_client = mocker.MagicMock()
+    mock_client.company_news.return_value = new_articles
+    mocker.patch(
+        "rdd.pipelines.company_news.nodes.finnhub.Client", return_value=mock_client
+    )
+
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("raw_company_news")
+    assert ticker.lower() in result
+    assert len(result[ticker.lower()]) > len(existing_df)
+    call_kwargs = mock_client.company_news.call_args[1]
+    assert pd.Timestamp(call_kwargs["_from"]) > last_date

--- a/tests/schemas/test_company_info_schema.py
+++ b/tests/schemas/test_company_info_schema.py
@@ -1,0 +1,60 @@
+"""Tests for CompanyInfoSchema validation."""
+
+from __future__ import annotations
+
+import pandera.pandas as pa
+import pytest
+
+from rdd.schemas.company_info import CompanyInfoSchema
+from tests.conftest import make_company_info_df
+
+
+class TestCompanyInfoSchema:
+    def test_valid_row_passes(self) -> None:
+        CompanyInfoSchema.validate(make_company_info_df())
+
+    def test_nullable_fields_accept_none(self) -> None:
+        df = make_company_info_df()
+        for col in [
+            "name",
+            "sector",
+            "industry",
+            "market_cap",
+            "employees",
+            "country",
+            "currency",
+            "exchange",
+        ]:
+            bad = df.copy()
+            bad[col] = None
+            CompanyInfoSchema.validate(bad)
+
+    def test_ticker_not_nullable(self) -> None:
+        df = make_company_info_df()
+        df["ticker"] = None
+        with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
+            CompanyInfoSchema.validate(df)
+
+    def test_fetched_at_not_nullable(self) -> None:
+        df = make_company_info_df()
+        df["fetched_at"] = None
+        with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
+            CompanyInfoSchema.validate(df)
+
+    def test_negative_market_cap_rejected(self) -> None:
+        df = make_company_info_df()
+        df["market_cap"] = -1.0
+        with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
+            CompanyInfoSchema.validate(df)
+
+    def test_negative_employees_rejected(self) -> None:
+        df = make_company_info_df()
+        df["employees"] = -1.0
+        with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
+            CompanyInfoSchema.validate(df)
+
+    def test_extra_columns_rejected(self) -> None:
+        df = make_company_info_df()
+        df["unexpected_col"] = "x"
+        with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
+            CompanyInfoSchema.validate(df)

--- a/tests/schemas/test_company_news_schema.py
+++ b/tests/schemas/test_company_news_schema.py
@@ -1,0 +1,43 @@
+"""Tests for CompanyNewsSchema validation."""
+
+from __future__ import annotations
+
+import pandera.pandas as pa
+import pytest
+
+from rdd.schemas.company_news import CompanyNewsSchema
+from tests.conftest import make_company_news_df
+
+
+class TestCompanyNewsSchema:
+    def test_valid_df_passes(self) -> None:
+        CompanyNewsSchema.validate(make_company_news_df())
+
+    def test_nullable_fields_accept_none(self) -> None:
+        for col in ["headline", "summary", "source", "url", "category"]:
+            df = make_company_news_df()
+            df[col] = None
+            CompanyNewsSchema.validate(df)
+
+    def test_ticker_not_nullable(self) -> None:
+        df = make_company_news_df()
+        df["ticker"] = None
+        with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
+            CompanyNewsSchema.validate(df)
+
+    def test_published_at_not_nullable(self) -> None:
+        df = make_company_news_df()
+        df["published_at"] = None
+        with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
+            CompanyNewsSchema.validate(df)
+
+    def test_extra_columns_rejected(self) -> None:
+        df = make_company_news_df()
+        df["unexpected_col"] = "x"
+        with pytest.raises((pa.errors.SchemaError, pa.errors.SchemaErrors)):
+            CompanyNewsSchema.validate(df)
+
+    def test_published_at_coerced_from_string(self) -> None:
+        df = make_company_news_df()
+        df["published_at"] = df["published_at"].astype(str)
+        CompanyNewsSchema.validate(df)


### PR DESCRIPTION
## Summary

- **`company_info` pipeline** — fetches per-ticker metadata snapshots from yfinance (sector, industry, market cap, employees, country, currency, exchange). Staleness-aware: skips tickers whose snapshot is fresher than `refresh_days` (default 7 days).
- **`company_news` pipeline** — fetches article feeds from Finnhub incrementally, resuming from the day after the last stored article per ticker. Deduplicates on `(ticker, published_at, headline)`. Requires `FINNHUB_API_KEY` env var.
- Both pipelines consume `ticker_universe` from `data_ingestion`, follow the established `NullablePartitionedDataset` / `PartitionedDataset` read/write pattern, and have Pandera schemas validated at node boundaries by the existing `PanderaHook`.

## Test plan

- [ ] `uv run pytest tests/` — 71 tests, all green
- [ ] `uv run pre-commit run --files <all new files>` — passes clean
- [ ] Manual smoke: set `FINNHUB_API_KEY` and run `kedro run --pipeline company_news` with a small ticker universe
- [ ] Manual smoke: run `kedro run --pipeline company_info` and inspect `data/raw/company_info/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)