### PR TITLE
feat(scripts): daily ingest email report + independent pipeline execution

### DIFF
--- a/scripts/run_daily_ingest.sh
+++ b/scripts/run_daily_ingest.sh
@@ -17,6 +17,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 LOG_DIR="$PROJECT_ROOT/logs"
 LOG_FILE="$LOG_DIR/daily_ingest.log"
 DRY_RUN=false
+CRON_BRANCH="main"
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
@@ -83,6 +84,14 @@ send_report() {
     log "[EMAIL] failed to send report (check SMTP credentials in .env)"
 }
 
+sync_branch() {
+  log "[GIT] syncing to $CRON_BRANCH..."
+  git -C "$PROJECT_ROOT" fetch origin "$CRON_BRANCH" >> "$LOG_FILE" 2>&1
+  git -C "$PROJECT_ROOT" checkout "$CRON_BRANCH" >> "$LOG_FILE" 2>&1
+  git -C "$PROJECT_ROOT" pull --ff-only origin "$CRON_BRANCH" >> "$LOG_FILE" 2>&1
+  log "[GIT] HEAD=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
+}
+
 main() {
   if [[ -f "$PROJECT_ROOT/.env" ]]; then
     set -a
@@ -92,6 +101,7 @@ main() {
   fi
 
   log "=== daily ingest start ==="
+  sync_branch
 
   run_pipeline data_ingestion
   run_pipeline finnhub_news

--- a/scripts/run_daily_ingest.sh
+++ b/scripts/run_daily_ingest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Runs the RDD data ingestion pipelines sequentially.
+# Runs the RDD data ingestion pipelines independently.
 # Safe to call from cron — sets PATH explicitly and sources .env from the project root.
 #
 # Usage:
@@ -32,11 +32,21 @@ log() {
   echo "[$(ts)] $*" | tee -a "$LOG_FILE"
 }
 
+# Parallel arrays collecting results for the email report.
+PIPELINE_NAMES=()
+PIPELINE_STATUSES=()
+PIPELINE_LOG_FILES=()
+
 run_pipeline() {
   local pipeline="$1"
+  local pipeline_log="$LOG_DIR/${pipeline}_last.log"
+
+  PIPELINE_NAMES+=("$pipeline")
+  PIPELINE_LOG_FILES+=("$pipeline_log")
 
   if $DRY_RUN; then
     echo "[DRY-RUN] uv run kedro run --pipeline $pipeline"
+    PIPELINE_STATUSES+=("skip")
     return 0
   fi
 
@@ -45,12 +55,32 @@ run_pipeline() {
 
   if ! echo "$registered" | grep -qx "$pipeline"; then
     log "[SKIP] Pipeline '$pipeline' not registered — skipping"
+    PIPELINE_STATUSES+=("skip")
     return 0
   fi
 
   log "[START] $pipeline"
-  (cd "$PROJECT_ROOT" && uv run kedro run --pipeline "$pipeline") >> "$LOG_FILE" 2>&1
-  log "[OK]    $pipeline"
+  local exit_code=0
+  (cd "$PROJECT_ROOT" && uv run kedro run --pipeline "$pipeline") > "$pipeline_log" 2>&1 || exit_code=$?
+  cat "$pipeline_log" >> "$LOG_FILE"
+
+  if [[ $exit_code -eq 0 ]]; then
+    log "[OK]    $pipeline"
+    PIPELINE_STATUSES+=("ok")
+  else
+    log "[FAIL]  $pipeline (exit $exit_code)"
+    PIPELINE_STATUSES+=("fail")
+  fi
+}
+
+send_report() {
+  local args=()
+  for i in "${!PIPELINE_NAMES[@]}"; do
+    args+=("${PIPELINE_NAMES[$i]}" "${PIPELINE_STATUSES[$i]}" "${PIPELINE_LOG_FILES[$i]}")
+  done
+  log "[EMAIL] sending report..."
+  (cd "$PROJECT_ROOT" && uv run python scripts/send_report.py "${args[@]}") >> "$LOG_FILE" 2>&1 || \
+    log "[EMAIL] failed to send report (check SMTP credentials in .env)"
 }
 
 main() {
@@ -66,6 +96,10 @@ main() {
   run_pipeline data_ingestion
   run_pipeline finnhub_news
   run_pipeline newsapi_news
+
+  if ! $DRY_RUN; then
+    send_report
+  fi
 
   log "=== [DONE] ==="
 }

--- a/scripts/send_report.py
+++ b/scripts/send_report.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Send daily ingest report email via Gmail SMTP.
+
+Called by run_daily_ingest.sh with triplet args:
+    send_report.py <pipeline> <status> <log_path> [<pipeline> <status> <log_path> ...]
+
+Status values: ok | fail | skip
+"""
+
+import os
+import smtplib
+import ssl
+import sys
+from email.message import EmailMessage
+from pathlib import Path
+
+_LOG_TAIL = 50
+
+
+def _tail(path: str, n: int = _LOG_TAIL) -> str:
+    p = Path(path)
+    if not p.exists():
+        return "(log file not found)"
+    lines = p.read_text().splitlines()
+    return "\n".join(lines[-n:]) if lines else "(empty log)"
+
+
+def _subject(results: dict[str, str]) -> str:
+    failed = [p for p, s in results.items() if s == "fail"]
+    if not failed:
+        return "[RDD] Daily ingest OK"
+    return f"[RDD] Daily ingest FAILED: {', '.join(failed)}"
+
+
+def _body(results: dict[str, str], log_paths: dict[str, str]) -> str:
+    icons = {"ok": "✓", "skip": "—", "fail": "✗"}
+    lines = ["Daily ingest report\n"]
+    for pipeline, status in results.items():
+        lines.append(f"  {icons.get(status, '?')}  {pipeline}: {status.upper()}")
+
+    failed = [p for p, s in results.items() if s == "fail"]
+    if failed:
+        lines.append("\n--- Logs (last 50 lines per failed pipeline) ---")
+        for p in failed:
+            lines.append(f"\n=== {p} ===")
+            lines.append(_tail(log_paths.get(p, "")))
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    if not args or len(args) % 3 != 0:
+        sys.exit("Usage: send_report.py <pipeline> <status> <log_path> ...")
+
+    results: dict[str, str] = {}
+    log_paths: dict[str, str] = {}
+    for i in range(0, len(args), 3):
+        name, status, log_path = args[i], args[i + 1], args[i + 2]
+        results[name] = status
+        log_paths[name] = log_path
+
+    to_addr = os.environ["RDD_EMAIL_TO"]
+    smtp_host = os.environ.get("RDD_SMTP_HOST", "smtp.gmail.com")
+    smtp_port = int(os.environ.get("RDD_SMTP_PORT", "587"))
+    smtp_user = os.environ["RDD_SMTP_USER"]
+    smtp_pass = os.environ["RDD_SMTP_PASS"]
+
+    msg = EmailMessage()
+    msg["Subject"] = _subject(results)
+    msg["From"] = smtp_user
+    msg["To"] = to_addr
+    msg.set_content(_body(results, log_paths))
+
+    ctx = ssl.create_default_context()
+    with smtplib.SMTP_SSL(smtp_host, smtp_port, context=ctx, timeout=30) as conn:
+        conn.login(smtp_user, smtp_pass)
+        conn.send_message(msg)
+
+    print(f"Report sent to {to_addr}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Each pipeline now runs independently — one failure no longer aborts the other
- Post-run email sent via Gmail SMTP (port 465) with OK / FAIL / SKIP per pipeline; failures include the last 50 log lines
- Cron always syncs to `main` before running, so pipelines execute from the latest merged code

## Setup

Add to `.env` before the first real run:
```
RDD_EMAIL_TO=you@example.com
RDD_SMTP_USER=your-gmail@gmail.com
RDD_SMTP_PASS=your-app-password   # Gmail App Password
```

## Test plan

- [ ] `uv run python scripts/send_report.py data_ingestion ok /dev/null` sends an OK email
- [ ] `uv run python scripts/send_report.py data_ingestion fail /dev/null` sends a FAIL email with log tail
- [ ] `bash scripts/run_daily_ingest.sh --dry-run` shows git sync then pipeline dry-run lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)