### PR TITLE
fix(scripts): use kedro registry list and add launchd install scripts

### DIFF
--- a/scripts/install_launchd.sh
+++ b/scripts/install_launchd.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Installs the RDD daily ingest as a launchd agent at 17:00 local (10:00 UTC, Mon–Fri).
+# Unlike cron, launchd catches up missed runs when the machine wakes up.
+# Idempotent — safe to run multiple times.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+RUNNER="$SCRIPT_DIR/run_daily_ingest.sh"
+LOG_DIR="$PROJECT_ROOT/logs"
+LABEL="com.rdd.daily-ingest"
+PLIST_DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+mkdir -p "$LOG_DIR"
+
+# Remove any existing cron entry for this job.
+CURRENT=$(crontab -l 2>/dev/null || true)
+CLEANED=$(echo "$CURRENT" | grep -v "rdd-daily-ingest" | grep -v "run_daily_ingest" || true)
+if [[ "$CLEANED" != "$CURRENT" ]]; then
+  echo "$CLEANED" | grep -v '^$' | crontab - 2>/dev/null || crontab -r 2>/dev/null || true
+  echo "Removed existing cron entry."
+fi
+
+# Generate the plist with resolved absolute paths.
+cat > "$PLIST_DEST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$LABEL</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>$RUNNER</string>
+    </array>
+
+    <!-- 17:00 local (UTC+7) = 10:00 UTC, weekdays only -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>17</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>17</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>17</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>17</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>17</integer><key>Minute</key><integer>0</integer></dict>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/Paul_Mora/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>$HOME</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>$LOG_DIR/launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>$LOG_DIR/launchd.log</string>
+</dict>
+</plist>
+PLIST
+
+# Reload the agent.
+launchctl unload "$PLIST_DEST" 2>/dev/null || true
+launchctl load "$PLIST_DEST"
+
+echo "Installed launchd agent: $LABEL"
+echo "Runs Mon–Fri at 17:00 local (10:00 UTC). Catches up missed runs on wake."
+echo "Plist: $PLIST_DEST"

--- a/scripts/run_daily_ingest.sh
+++ b/scripts/run_daily_ingest.sh
@@ -52,9 +52,9 @@ run_pipeline() {
   fi
 
   local registered
-  registered=$(cd "$PROJECT_ROOT" && uv run kedro pipeline list 2>/dev/null || true)
+  registered=$(cd "$PROJECT_ROOT" && uv run kedro registry list 2>/dev/null || true)
 
-  if ! echo "$registered" | grep -qx "$pipeline"; then
+  if ! echo "$registered" | grep -q "\b${pipeline}\b"; then
     log "[SKIP] Pipeline '$pipeline' not registered — skipping"
     PIPELINE_STATUSES+=("skip")
     return 0

--- a/scripts/uninstall_launchd.sh
+++ b/scripts/uninstall_launchd.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Uninstalls the RDD launchd agent.
+
+set -euo pipefail
+
+LABEL="com.rdd.daily-ingest"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+launchctl unload "$PLIST" 2>/dev/null || true
+rm -f "$PLIST"
+echo "Removed launchd agent: $LABEL"


### PR DESCRIPTION
## Summary
- Replaces `kedro pipeline list` (doesn't exist in this version) with `kedro registry list`
- Fixes `grep -qx` to word-boundary `grep -q "\b${pipeline}\b"` — output format is `- pipeline_name` so exact-match was always failing
- Adds `install_launchd.sh` and `uninstall_launchd.sh` from PR #31

**Impact:** all three pipelines (`data_ingestion`, `company_info`, `company_news`) were being silently skipped on every cron run. This fix makes them actually execute.

Supersedes #31 (which can now be closed).

## Test plan
- [ ] CI passes
- [ ] Dry-run output unchanged (pipelines still listed correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)