### PR TITLE
feat(strategies): momentum, trend, and mean-reversion signal pipeline

### DIFF
--- a/conf/base/catalog/catalog_strategies.yml
+++ b/conf/base/catalog/catalog_strategies.yml
@@ -1,0 +1,17 @@
+# Intermediate signal dicts — in-memory only, not persisted between runs.
+momentum_signals:
+  type: MemoryDataset
+
+trend_signals:
+  type: MemoryDataset
+
+mean_reversion_signals:
+  type: MemoryDataset
+
+# Final output: one JSON object per ticker, consumed by the agent debate system.
+stock_analyses:
+  type: kedro_datasets.json.JSONDataset
+  filepath: ${globals:data_dir}strategies/stock_analyses.json
+  metadata:
+    kedro-viz:
+      layer: primary

--- a/conf/base/parameters/params_strategies.yml
+++ b/conf/base/parameters/params_strategies.yml
@@ -1,0 +1,22 @@
+strategies:
+  # Momentum: return windows in trading days
+  momentum_windows:
+    1m: 21
+    3m: 63
+    6m: 126
+    12m: 252
+  # Minimum number of positive windows to be bullish (out of 4)
+  momentum_min_bullish: 3
+
+  # Trend: moving-average windows in trading days
+  trend_short_window: 50
+  trend_long_window: 200
+
+  # Mean reversion: RSI settings
+  rsi_window: 14
+  rsi_oversold: 30.0
+  rsi_overbought: 70.0
+
+  # Mean reversion: Bollinger Band settings
+  bb_window: 20
+  bb_std: 2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,9 @@ fixable = ["ALL"]
     "PLR0912", # ingest_ohlcv has many branches — intentional complexity
     "PLR0915", # ingest_ohlcv has many statements — intentional complexity
 ]
+"src/rdd/pipelines/strategies/nodes.py" = [
+    "PLR0912", # per-strategy nodes have intentional branching for direction logic
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/rdd/pipeline_registry.py
+++ b/src/rdd/pipeline_registry.py
@@ -5,6 +5,7 @@ from kedro.pipeline import Pipeline
 from rdd.pipelines.company_info.pipeline import create_pipeline as company_info
 from rdd.pipelines.company_news.pipeline import create_pipeline as company_news
 from rdd.pipelines.data_ingestion.pipeline import create_pipeline as data_ingestion
+from rdd.pipelines.strategies.pipeline import create_pipeline as strategies
 
 
 def register_pipelines() -> dict[str, Pipeline]:
@@ -12,9 +13,11 @@ def register_pipelines() -> dict[str, Pipeline]:
     di = data_ingestion()
     ci = company_info()
     cn = company_news()
+    st = strategies()
     return {
-        "__default__": di + ci + cn,
+        "__default__": di + ci + cn + st,
         "data_ingestion": di,
         "company_info": ci,
         "company_news": cn,
+        "strategies": st,
     }

--- a/src/rdd/pipelines/strategies/__init__.py
+++ b/src/rdd/pipelines/strategies/__init__.py
@@ -1,0 +1,1 @@
+"""Strategies pipeline — computes per-ticker trading signals from ingested data."""

--- a/src/rdd/pipelines/strategies/models.py
+++ b/src/rdd/pipelines/strategies/models.py
@@ -1,0 +1,38 @@
+"""Strategy output data models."""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+
+@dataclass
+class StrategySignal:
+    """A single strategy verdict for one ticker."""
+
+    strategy: str
+    direction: Literal["bullish", "bearish", "neutral"]
+    metrics: dict[str, Any]
+
+
+@dataclass
+class StockAnalysis:
+    """Aggregated strategy signals for one ticker."""
+
+    ticker: str
+    signals: list[StrategySignal]
+    generated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "ticker": self.ticker,
+            "generated_at": self.generated_at.isoformat(),
+            "signals": [
+                {
+                    "strategy": s.strategy,
+                    "direction": s.direction,
+                    "metrics": s.metrics,
+                }
+                for s in self.signals
+            ],
+        }

--- a/src/rdd/pipelines/strategies/nodes.py
+++ b/src/rdd/pipelines/strategies/nodes.py
@@ -1,0 +1,216 @@
+"""Strategy signal computation nodes."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pandas as pd
+
+from rdd.pipelines.strategies.models import StockAnalysis, StrategySignal
+
+
+def compute_momentum_signals(
+    ohlcv: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> dict[str, StrategySignal]:
+    """Compute price-return momentum signals over configurable lookback windows.
+
+    Direction is bullish when at least ``momentum_min_bullish`` windows show a
+    positive return, bearish when fewer than ``total - momentum_min_bullish``
+    windows are positive, and neutral otherwise.
+
+    Args:
+        ohlcv: Partitioned OHLCV dataset, keyed by lowercase ticker symbol.
+        params: Strategy parameters (see ``params_strategies.yml``).
+
+    Returns:
+        Mapping of ticker key to momentum ``StrategySignal``.
+    """
+    windows: dict[str, int] = params.get(
+        "momentum_windows", {"1m": 21, "3m": 63, "6m": 126, "12m": 252}
+    )
+    min_bullish: int = params.get("momentum_min_bullish", 3)
+    signals: dict[str, StrategySignal] = {}
+
+    for ticker_key, loader in ohlcv.items():
+        df = loader().sort_values("date")
+        prices = df["adj_close"].dropna()
+        if len(prices) < 2:
+            continue
+
+        metrics: dict[str, Any] = {}
+        positive_count = 0
+        total = 0
+
+        for label, days in windows.items():
+            if len(prices) > days:
+                ret = round(float(prices.iloc[-1] / prices.iloc[-days] - 1), 4)
+                metrics[f"return_{label}"] = ret
+                if ret > 0:
+                    positive_count += 1
+                total += 1
+
+        if total == 0:
+            continue
+
+        if positive_count >= min_bullish:
+            direction = "bullish"
+        elif positive_count <= total - min_bullish:
+            direction = "bearish"
+        else:
+            direction = "neutral"
+
+        signals[ticker_key] = StrategySignal(
+            strategy="momentum", direction=direction, metrics=metrics
+        )
+
+    return signals
+
+
+def compute_trend_signals(
+    ohlcv: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> dict[str, StrategySignal]:
+    """Compute moving-average trend signals (golden / death cross).
+
+    When both MAs are available, direction follows the MA cross: bullish on a
+    golden cross (short > long), bearish on a death cross. When only the short
+    MA is available, direction follows price vs. short MA.
+
+    Args:
+        ohlcv: Partitioned OHLCV dataset, keyed by lowercase ticker symbol.
+        params: Strategy parameters (see ``params_strategies.yml``).
+
+    Returns:
+        Mapping of ticker key to trend ``StrategySignal``.
+    """
+    short_window: int = params.get("trend_short_window", 50)
+    long_window: int = params.get("trend_long_window", 200)
+    signals: dict[str, StrategySignal] = {}
+
+    for ticker_key, loader in ohlcv.items():
+        df = loader().sort_values("date")
+        prices = df["adj_close"].dropna()
+        if len(prices) < short_window:
+            continue
+
+        ma_short = float(prices.rolling(short_window).mean().iloc[-1])
+        price = float(prices.iloc[-1])
+        price_vs_short_pct = round((price / ma_short - 1), 4)
+
+        metrics: dict[str, Any] = {
+            f"ma{short_window}": round(ma_short, 2),
+            "price_vs_ma_short_pct": price_vs_short_pct,
+        }
+
+        if len(prices) >= long_window:
+            ma_long = float(prices.rolling(long_window).mean().iloc[-1])
+            metrics[f"ma{long_window}"] = round(ma_long, 2)
+            metrics["cross"] = "golden" if ma_short > ma_long else "death"
+            direction = "bullish" if ma_short > ma_long else "bearish"
+        else:
+            direction = "bullish" if price_vs_short_pct > 0 else "bearish"
+
+        signals[ticker_key] = StrategySignal(
+            strategy="trend", direction=direction, metrics=metrics
+        )
+
+    return signals
+
+
+def compute_mean_reversion_signals(
+    ohlcv: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> dict[str, StrategySignal]:
+    """Compute mean-reversion signals via RSI and Bollinger Bands.
+
+    RSI below ``rsi_oversold`` signals a bullish (oversold) condition; above
+    ``rsi_overbought`` signals bearish (overbought). Bollinger Band position
+    is reported as a 0-1 fraction (0 = lower band, 1 = upper band).
+
+    Args:
+        ohlcv: Partitioned OHLCV dataset, keyed by lowercase ticker symbol.
+        params: Strategy parameters (see ``params_strategies.yml``).
+
+    Returns:
+        Mapping of ticker key to mean-reversion ``StrategySignal``.
+    """
+    rsi_window: int = params.get("rsi_window", 14)
+    rsi_oversold: float = params.get("rsi_oversold", 30.0)
+    rsi_overbought: float = params.get("rsi_overbought", 70.0)
+    bb_window: int = params.get("bb_window", 20)
+    bb_std: float = params.get("bb_std", 2.0)
+    signals: dict[str, StrategySignal] = {}
+
+    for ticker_key, loader in ohlcv.items():
+        df = loader().sort_values("date")
+        prices = df["adj_close"].dropna()
+        if len(prices) < max(rsi_window + 1, bb_window):
+            continue
+
+        # RSI via simple rolling averages
+        delta = prices.diff()
+        avg_gain = delta.clip(lower=0).rolling(rsi_window).mean()
+        avg_loss = (-delta.clip(upper=0)).rolling(rsi_window).mean()
+        # avg_loss=0 means pure gains → RS → ∞ → RSI → 100; avoid div-by-zero
+        rs = avg_gain / avg_loss.replace(0, 1e-10)
+        rsi = float((100 - 100 / (1 + rs)).iloc[-1])
+
+        # Bollinger Bands
+        ma = float(prices.rolling(bb_window).mean().iloc[-1])
+        std = float(prices.rolling(bb_window).std().iloc[-1])
+        bb_upper = ma + bb_std * std
+        bb_lower = ma - bb_std * std
+        price = float(prices.iloc[-1])
+        band_width = bb_upper - bb_lower
+        bb_position = round((price - bb_lower) / band_width, 2) if band_width > 0 else 0.5
+
+        metrics: dict[str, Any] = {
+            f"rsi_{rsi_window}": round(rsi, 1),
+            "bb_position": bb_position,
+            "bb_upper": round(bb_upper, 2),
+            "bb_lower": round(bb_lower, 2),
+        }
+
+        if rsi < rsi_oversold:
+            direction = "bullish"
+        elif rsi > rsi_overbought:
+            direction = "bearish"
+        else:
+            direction = "neutral"
+
+        signals[ticker_key] = StrategySignal(
+            strategy="mean_reversion", direction=direction, metrics=metrics
+        )
+
+    return signals
+
+
+def assemble_stock_analyses(
+    momentum: dict[str, StrategySignal],
+    trend: dict[str, StrategySignal],
+    mean_reversion: dict[str, StrategySignal],
+) -> dict[str, dict[str, Any]]:
+    """Combine per-strategy signals into one ``StockAnalysis`` per ticker.
+
+    Args:
+        momentum: Momentum signals keyed by lowercase ticker.
+        trend: Trend signals keyed by lowercase ticker.
+        mean_reversion: Mean-reversion signals keyed by lowercase ticker.
+
+    Returns:
+        Mapping of lowercase ticker to serialised ``StockAnalysis`` dict,
+        ready for JSON persistence.
+    """
+    all_tickers = set(momentum) | set(trend) | set(mean_reversion)
+    result: dict[str, dict[str, Any]] = {}
+
+    for ticker_key in sorted(all_tickers):
+        signals = [
+            sig
+            for sig_map in (momentum, trend, mean_reversion)
+            if (sig := sig_map.get(ticker_key)) is not None
+        ]
+        analysis = StockAnalysis(ticker=ticker_key.upper(), signals=signals)
+        result[ticker_key] = analysis.to_dict()
+
+    return result

--- a/src/rdd/pipelines/strategies/pipeline.py
+++ b/src/rdd/pipelines/strategies/pipeline.py
@@ -1,0 +1,42 @@
+"""Strategies pipeline — derives trading signals from ingested OHLCV data."""
+
+from kedro.pipeline import Pipeline, node
+
+from rdd.pipelines.strategies.nodes import (
+    assemble_stock_analyses,
+    compute_mean_reversion_signals,
+    compute_momentum_signals,
+    compute_trend_signals,
+)
+
+
+def create_pipeline(**_kwargs) -> Pipeline:
+    """Create the strategies pipeline."""
+    return Pipeline(
+        nodes=[
+            node(
+                func=compute_momentum_signals,
+                inputs=["raw_ohlcv", "params:strategies"],
+                outputs="momentum_signals",
+                name="compute_momentum_signals",
+            ),
+            node(
+                func=compute_trend_signals,
+                inputs=["raw_ohlcv", "params:strategies"],
+                outputs="trend_signals",
+                name="compute_trend_signals",
+            ),
+            node(
+                func=compute_mean_reversion_signals,
+                inputs=["raw_ohlcv", "params:strategies"],
+                outputs="mean_reversion_signals",
+                name="compute_mean_reversion_signals",
+            ),
+            node(
+                func=assemble_stock_analyses,
+                inputs=["momentum_signals", "trend_signals", "mean_reversion_signals"],
+                outputs="stock_analyses",
+                name="assemble_stock_analyses",
+            ),
+        ]
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,3 +86,28 @@ def make_company_news_df(
 def company_news_df() -> pd.DataFrame:
     """Three-row company news DataFrame that satisfies CompanyNewsSchema (AAPL)."""
     return make_company_news_df()
+
+
+def make_price_ohlcv(
+    prices: list[float],
+    ticker: str = "AAPL",
+    start: str = "2024-01-02",
+) -> pd.DataFrame:
+    """Return an OHLCV DataFrame driven by an explicit *prices* list.
+
+    Suitable for strategy tests that need controlled price trajectories (trends,
+    RSI scenarios) without going through the Pandera example generator.
+    """
+    n = len(prices)
+    return pd.DataFrame(
+        {
+            "ticker": [ticker] * n,
+            "date": pd.date_range(start, periods=n, freq="B"),
+            "adj_close": prices,
+            "close": prices,
+            "open": [p * 1.005 for p in prices],
+            "high": [p * 1.01 for p in prices],
+            "low": [p * 0.99 for p in prices],
+            "volume": [1_000_000.0] * n,
+        }
+    )

--- a/tests/pipelines/strategies/__init__.py
+++ b/tests/pipelines/strategies/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the strategies pipeline."""

--- a/tests/pipelines/strategies/test_nodes.py
+++ b/tests/pipelines/strategies/test_nodes.py
@@ -1,0 +1,265 @@
+"""Unit tests for strategies pipeline nodes.
+
+Each node is tested in isolation with synthetic price series designed to
+produce unambiguous signal directions, so test intent is self-evident from
+the data rather than from magic expected values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pandas as pd
+import pytest
+
+from rdd.pipelines.strategies.models import StrategySignal
+from rdd.pipelines.strategies.nodes import (
+    assemble_stock_analyses,
+    compute_mean_reversion_signals,
+    compute_momentum_signals,
+    compute_trend_signals,
+)
+from tests.conftest import make_price_ohlcv
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_UPTREND = [100.0 + i * 0.5 for i in range(260)]   # 260 days, steadily rising
+_DOWNTREND = [230.0 - i * 0.5 for i in range(260)]  # 260 days, steadily falling
+
+
+def _ohlcv(df: pd.DataFrame, key: str = "aapl") -> dict[str, Callable[[], pd.DataFrame]]:
+    return {key: lambda _df=df: _df}
+
+
+@pytest.fixture
+def params() -> dict:
+    return {
+        "momentum_windows": {"1m": 21, "3m": 63, "6m": 126, "12m": 252},
+        "momentum_min_bullish": 3,
+        "trend_short_window": 50,
+        "trend_long_window": 200,
+        "rsi_window": 14,
+        "rsi_oversold": 30.0,
+        "rsi_overbought": 70.0,
+        "bb_window": 20,
+        "bb_std": 2.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# compute_momentum_signals
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMomentumSignals:
+    def test_uptrend_is_bullish(self, params) -> None:
+        result = compute_momentum_signals(_ohlcv(make_price_ohlcv(_UPTREND)), params)
+
+        assert result["aapl"].direction == "bullish"
+
+    def test_downtrend_is_bearish(self, params) -> None:
+        result = compute_momentum_signals(_ohlcv(make_price_ohlcv(_DOWNTREND)), params)
+
+        assert result["aapl"].direction == "bearish"
+
+    def test_metrics_contain_all_four_windows(self, params) -> None:
+        result = compute_momentum_signals(_ohlcv(make_price_ohlcv(_UPTREND)), params)
+
+        assert set(result["aapl"].metrics.keys()) == {
+            "return_1m",
+            "return_3m",
+            "return_6m",
+            "return_12m",
+        }
+
+    def test_short_series_only_emits_available_windows(self, params) -> None:
+        # 30 rows → only 1m (21d) window fits; 3m/6m/12m are skipped
+        prices = [100.0 + i * 0.5 for i in range(30)]
+        result = compute_momentum_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert "return_1m" in result["aapl"].metrics
+        assert "return_3m" not in result["aapl"].metrics
+
+    def test_single_row_ticker_is_skipped(self, params) -> None:
+        result = compute_momentum_signals(_ohlcv(make_price_ohlcv([100.0])), params)
+
+        assert "aapl" not in result
+
+    def test_multiple_tickers_are_independent(self, params) -> None:
+        ohlcv = {
+            "aapl": lambda: make_price_ohlcv(_UPTREND, ticker="AAPL"),
+            "msft": lambda: make_price_ohlcv(_DOWNTREND, ticker="MSFT"),
+        }
+        result = compute_momentum_signals(ohlcv, params)
+
+        assert result["aapl"].direction == "bullish"
+        assert result["msft"].direction == "bearish"
+
+
+# ---------------------------------------------------------------------------
+# compute_trend_signals
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTrendSignals:
+    def test_golden_cross_is_bullish(self, params) -> None:
+        # Uptrend → MA50 > MA200 → golden cross
+        result = compute_trend_signals(_ohlcv(make_price_ohlcv(_UPTREND)), params)
+
+        assert result["aapl"].direction == "bullish"
+        assert result["aapl"].metrics.get("cross") == "golden"
+
+    def test_death_cross_is_bearish(self, params) -> None:
+        result = compute_trend_signals(_ohlcv(make_price_ohlcv(_DOWNTREND)), params)
+
+        assert result["aapl"].direction == "bearish"
+        assert result["aapl"].metrics.get("cross") == "death"
+
+    def test_short_series_uses_price_vs_ma50(self, params) -> None:
+        # 60 rows: MA50 available, MA200 not — direction follows price vs MA50
+        prices = [100.0 + i * 0.5 for i in range(60)]  # rising → price > MA50
+        result = compute_trend_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert result["aapl"].direction == "bullish"
+        assert "cross" not in result["aapl"].metrics
+        assert "ma200" not in result["aapl"].metrics
+
+    def test_insufficient_data_ticker_is_skipped(self, params) -> None:
+        prices = [100.0 + i for i in range(10)]
+        result = compute_trend_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert "aapl" not in result
+
+    def test_metrics_contain_ma_values(self, params) -> None:
+        result = compute_trend_signals(_ohlcv(make_price_ohlcv(_UPTREND)), params)
+        metrics = result["aapl"].metrics
+
+        assert "ma50" in metrics
+        assert "ma200" in metrics
+        assert "price_vs_ma_short_pct" in metrics
+
+
+# ---------------------------------------------------------------------------
+# compute_mean_reversion_signals
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMeanReversionSignals:
+    def test_declining_prices_are_oversold_bullish(self, params) -> None:
+        # Pure decline → RSI ≈ 0 (< 30) → bullish
+        prices = [200.0 - i * 2.0 for i in range(30)]
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert result["aapl"].direction == "bullish"
+        assert result["aapl"].metrics[f"rsi_{params['rsi_window']}"] < 30
+
+    def test_rising_prices_are_overbought_bearish(self, params) -> None:
+        # Pure rise → RSI ≈ 100 (> 70) → bearish
+        prices = [100.0 + i * 2.0 for i in range(30)]
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert result["aapl"].direction == "bearish"
+        assert result["aapl"].metrics[f"rsi_{params['rsi_window']}"] > 70
+
+    def test_alternating_prices_are_neutral(self, params) -> None:
+        # Equal up/down moves → RSI ≈ 50 → neutral
+        prices = [100.0 + (1.0 if i % 2 == 0 else -1.0) * (i // 2 + 1) for i in range(30)]
+        # Simpler: fixed alternating deltas from a constant base
+        base = 100.0
+        prices = []
+        for i in range(30):
+            base += 1.0 if i % 2 == 0 else -1.0
+            prices.append(base)
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert result["aapl"].direction == "neutral"
+
+    def test_insufficient_data_ticker_is_skipped(self, params) -> None:
+        prices = [100.0 + i for i in range(5)]
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert "aapl" not in result
+
+    def test_metrics_contain_bb_and_rsi(self, params) -> None:
+        prices = [200.0 - i * 2.0 for i in range(30)]
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+        metrics = result["aapl"].metrics
+
+        assert f"rsi_{params['rsi_window']}" in metrics
+        assert "bb_position" in metrics
+        assert "bb_upper" in metrics
+        assert "bb_lower" in metrics
+
+    def test_bb_position_within_zero_one(self, params) -> None:
+        prices = [100.0 + i * 0.1 for i in range(30)]
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        bb_pos = result["aapl"].metrics["bb_position"]
+        assert 0.0 <= bb_pos <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# assemble_stock_analyses
+# ---------------------------------------------------------------------------
+
+
+def _make_signal(strategy: str) -> StrategySignal:
+    return StrategySignal(strategy=strategy, direction="bullish", metrics={})
+
+
+class TestAssembleStockAnalyses:
+    def test_output_contains_all_tickers(self) -> None:
+        momentum = {"aapl": _make_signal("momentum"), "msft": _make_signal("momentum")}
+        trend = {"aapl": _make_signal("trend"), "msft": _make_signal("trend")}
+        mean_rev = {"aapl": _make_signal("mean_reversion")}
+
+        result = assemble_stock_analyses(momentum, trend, mean_rev)
+
+        assert "aapl" in result
+        assert "msft" in result
+
+    def test_ticker_is_uppercased_in_output(self) -> None:
+        signal = {"aapl": _make_signal("momentum")}
+        result = assemble_stock_analyses(signal, {}, {})
+
+        assert result["aapl"]["ticker"] == "AAPL"
+
+    def test_all_three_strategy_signals_present(self) -> None:
+        sig = {"aapl": _make_signal("momentum")}
+        trend = {"aapl": _make_signal("trend")}
+        mean_rev = {"aapl": _make_signal("mean_reversion")}
+
+        result = assemble_stock_analyses(sig, trend, mean_rev)
+        strategies = {s["strategy"] for s in result["aapl"]["signals"]}
+
+        assert strategies == {"momentum", "trend", "mean_reversion"}
+
+    def test_missing_strategy_excluded_from_signals(self) -> None:
+        # mean_reversion skipped ticker (e.g. insufficient data)
+        result = assemble_stock_analyses(
+            {"aapl": _make_signal("momentum")},
+            {"aapl": _make_signal("trend")},
+            {},
+        )
+
+        strategies = {s["strategy"] for s in result["aapl"]["signals"]}
+        assert "mean_reversion" not in strategies
+        assert len(result["aapl"]["signals"]) == 2
+
+    def test_output_has_required_top_level_keys(self) -> None:
+        result = assemble_stock_analyses({"aapl": _make_signal("momentum")}, {}, {})
+        entry = result["aapl"]
+
+        assert {"ticker", "generated_at", "signals"} <= entry.keys()
+
+    def test_tickers_are_sorted_in_output(self) -> None:
+        signals = {
+            "msft": _make_signal("momentum"),
+            "aapl": _make_signal("momentum"),
+            "goog": _make_signal("momentum"),
+        }
+        result = assemble_stock_analyses(signals, {}, {})
+
+        assert list(result.keys()) == sorted(result.keys())

--- a/tests/pipelines/strategies/test_pipeline.py
+++ b/tests/pipelines/strategies/test_pipeline.py
@@ -1,0 +1,138 @@
+"""Integration tests for the strategies pipeline.
+
+Runs the full strategies pipeline (momentum → trend → mean_reversion →
+assemble) via SequentialRunner with a fully in-memory DataCatalog.
+No network calls, no filesystem I/O.
+"""
+
+from __future__ import annotations
+
+import pytest
+from kedro.io import DataCatalog, MemoryDataset
+from kedro.runner import SequentialRunner
+
+from rdd.pipelines.strategies.pipeline import create_pipeline
+from tests.conftest import make_price_ohlcv
+
+_UPTREND = [100.0 + i * 0.5 for i in range(260)]
+_DOWNTREND = [230.0 - i * 0.5 for i in range(260)]
+
+
+@pytest.fixture
+def pipeline():
+    """The strategies Kedro pipeline."""
+    return create_pipeline()
+
+
+@pytest.fixture
+def params() -> dict:
+    return {
+        "momentum_windows": {"1m": 21, "3m": 63, "6m": 126, "12m": 252},
+        "momentum_min_bullish": 3,
+        "trend_short_window": 50,
+        "trend_long_window": 200,
+        "rsi_window": 14,
+        "rsi_oversold": 30.0,
+        "rsi_overbought": 70.0,
+        "bb_window": 20,
+        "bb_std": 2.0,
+    }
+
+
+@pytest.fixture
+def catalog(params) -> DataCatalog:
+    """In-memory catalog with two tickers of sufficient history."""
+    aapl_df = make_price_ohlcv(_UPTREND, ticker="AAPL")
+    msft_df = make_price_ohlcv(_DOWNTREND, ticker="MSFT")
+    return DataCatalog(
+        {
+            "params:strategies": MemoryDataset(data=params),
+            "raw_ohlcv": MemoryDataset(
+                data={
+                    "aapl": lambda: aapl_df,
+                    "msft": lambda: msft_df,
+                }
+            ),
+            "momentum_signals": MemoryDataset(),
+            "trend_signals": MemoryDataset(),
+            "mean_reversion_signals": MemoryDataset(),
+            "stock_analyses": MemoryDataset(),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_runs_without_error(pipeline, catalog) -> None:
+    """Full pipeline executes end-to-end without raising."""
+    SequentialRunner().run(pipeline, catalog)
+
+
+def test_pipeline_produces_stock_analyses(pipeline, catalog) -> None:
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("stock_analyses")
+    assert isinstance(result, dict)
+    assert len(result) == 2
+    assert "aapl" in result
+    assert "msft" in result
+
+
+def test_pipeline_output_structure(pipeline, catalog) -> None:
+    """Each entry has the expected top-level keys and signal list shape."""
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("stock_analyses")
+    for entry in result.values():
+        assert {"ticker", "generated_at", "signals"} <= entry.keys()
+        for signal in entry["signals"]:
+            assert {"strategy", "direction", "metrics"} <= signal.keys()
+            assert signal["direction"] in {"bullish", "bearish", "neutral"}
+
+
+def test_pipeline_emits_all_three_strategies(pipeline, catalog) -> None:
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("stock_analyses")
+    for entry in result.values():
+        strategies = {s["strategy"] for s in entry["signals"]}
+        assert strategies == {"momentum", "trend", "mean_reversion"}
+
+
+def test_pipeline_ticker_is_uppercase(pipeline, catalog) -> None:
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("stock_analyses")
+    assert result["aapl"]["ticker"] == "AAPL"
+    assert result["msft"]["ticker"] == "MSFT"
+
+
+def test_pipeline_skips_tickers_with_insufficient_data(pipeline, params) -> None:
+    """A ticker with only 5 rows produces no signals but does not crash."""
+    short_df = make_price_ohlcv([100.0 + i for i in range(5)], ticker="SHORT")
+    full_df = make_price_ohlcv(_UPTREND, ticker="AAPL")
+
+    catalog = DataCatalog(
+        {
+            "params:strategies": MemoryDataset(data=params),
+            "raw_ohlcv": MemoryDataset(
+                data={
+                    "aapl": lambda: full_df,
+                    "short": lambda: short_df,
+                }
+            ),
+            "momentum_signals": MemoryDataset(),
+            "trend_signals": MemoryDataset(),
+            "mean_reversion_signals": MemoryDataset(),
+            "stock_analyses": MemoryDataset(),
+        }
+    )
+
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("stock_analyses")
+    assert "aapl" in result
+    assert "short" not in result


### PR DESCRIPTION
## Summary

- Adds a `strategies` Kedro pipeline that derives per-ticker trading signals from ingested OHLCV data and writes `data/strategies/stock_analyses.json` for downstream agent consumption
- Implements three price-based strategies: **momentum** (1m/3m/6m/12m returns), **trend** (MA50/MA200 golden-death cross), **mean-reversion** (RSI + Bollinger Bands)
- Introduces `StrategySignal` / `StockAnalysis` dataclasses with `to_dict()` JSON serialisation
- All thresholds and windows are parameterised in `params_strategies.yml`
- Fixes RSI div-by-zero on pure-gain price series (replaces `avg_loss=0` with `1e-10`)
- Fundamental and sentiment strategies tracked in issue #34 pending richer ingested data

## New files

| Path | Purpose |
|---|---|
| `src/rdd/pipelines/strategies/` | Pipeline nodes, models, and Kedro wiring |
| `conf/base/catalog/catalog_strategies.yml` | Intermediate MemoryDatasets + JSON output |
| `conf/base/parameters/params_strategies.yml` | Configurable strategy parameters |
| `tests/pipelines/strategies/` | 29 tests (23 unit + 6 pipeline integration) |

## Test plan

- [ ] `uv run pytest tests/pipelines/strategies/ -v` — all 29 pass
- [ ] `uv run pytest tests/ --ignore=tests/scripts/` — full suite (99 tests) passes
- [ ] `kedro run --pipeline strategies` runs end-to-end after data ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)