### PR TITLE
feat(strategies): price-based signal pipeline with GARCH volatility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,16 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python-uv
       - name: Run pytest
-        run: uv run --locked pytest
+        run: uv run --locked pytest --ignore=tests/scripts
+
+  pytest-scripts:
+    name: pytest-scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-uv
+      - name: Run script tests
+        run: uv run --locked pytest tests/scripts
 
   check-uv-lock:
     name: check-uv-lock

--- a/conf/base/catalog/catalog_strategies.yml
+++ b/conf/base/catalog/catalog_strategies.yml
@@ -1,0 +1,17 @@
+# Intermediate signal dicts — in-memory only, not persisted between runs.
+momentum_signals:
+  type: MemoryDataset
+
+trend_signals:
+  type: MemoryDataset
+
+mean_reversion_signals:
+  type: MemoryDataset
+
+# Final output: one JSON object per ticker, consumed by the agent debate system.
+stock_analyses:
+  type: kedro_datasets.json.JSONDataset
+  filepath: ${globals:data_dir}strategies/stock_analyses.json
+  metadata:
+    kedro-viz:
+      layer: primary

--- a/conf/base/catalog/catalog_strategies.yml
+++ b/conf/base/catalog/catalog_strategies.yml
@@ -8,6 +8,9 @@ trend_signals:
 mean_reversion_signals:
   type: MemoryDataset
 
+volatility_signals:
+  type: MemoryDataset
+
 # Final output: one JSON object per ticker, consumed by the agent debate system.
 stock_analyses:
   type: kedro_datasets.json.JSONDataset

--- a/conf/base/parameters/params_strategies.yml
+++ b/conf/base/parameters/params_strategies.yml
@@ -1,0 +1,22 @@
+strategies:
+  # Momentum: return windows in trading days
+  momentum_windows:
+    1m: 21
+    3m: 63
+    6m: 126
+    12m: 252
+  # Minimum number of positive windows to be bullish (out of 4)
+  momentum_min_bullish: 3
+
+  # Trend: moving-average windows in trading days
+  trend_short_window: 50
+  trend_long_window: 200
+
+  # Mean reversion: RSI settings
+  rsi_window: 14
+  rsi_oversold: 30.0
+  rsi_overbought: 70.0
+
+  # Mean reversion: Bollinger Band settings
+  bb_window: 20
+  bb_std: 2.0

--- a/conf/base/parameters/params_strategies.yml
+++ b/conf/base/parameters/params_strategies.yml
@@ -20,3 +20,8 @@ strategies:
   # Mean reversion: Bollinger Band settings
   bb_window: 20
   bb_std: 2.0
+
+  # Volatility: GARCH(1,1) settings
+  garch_min_obs: 252          # minimum trading days required to fit the model
+  garch_vol_ratio_high: 1.5   # current/long-run vol ratio above which = bearish regime
+  garch_vol_ratio_low: 0.75   # current/long-run vol ratio below which = bullish regime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "kedro-datasets[pandas-parquetdataset]>=9.2",
     "pandera>=0.21",
     "lxml>=5.0",
+    "arch>=8.0.0",
 ]
 
 [tool.uv]
@@ -110,6 +111,10 @@ fixable = ["ALL"]
 "src/rdd/pipelines/data_ingestion/nodes.py" = [
     "PLR0912", # ingest_ohlcv has many branches — intentional complexity
     "PLR0915", # ingest_ohlcv has many statements — intentional complexity
+]
+"src/rdd/pipelines/strategies/nodes.py" = [
+    "PLR0912", # per-strategy nodes have intentional branching for direction logic
+    "S112",    # GARCH fit failures are silently skipped — ticker excluded from output
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/scripts/run_daily_ingest.sh
+++ b/scripts/run_daily_ingest.sh
@@ -123,6 +123,7 @@ main() {
   run_pipeline company_info
   run_pipeline company_news
   backfill_news
+  run_pipeline strategies
 
   if ! $DRY_RUN; then
     send_report

--- a/src/rdd/pipeline_registry.py
+++ b/src/rdd/pipeline_registry.py
@@ -5,6 +5,7 @@ from kedro.pipeline import Pipeline
 from rdd.pipelines.company_info.pipeline import create_pipeline as company_info
 from rdd.pipelines.company_news.pipeline import create_pipeline as company_news
 from rdd.pipelines.data_ingestion.pipeline import create_pipeline as data_ingestion
+from rdd.pipelines.strategies.pipeline import create_pipeline as strategies
 
 
 def register_pipelines() -> dict[str, Pipeline]:
@@ -12,9 +13,11 @@ def register_pipelines() -> dict[str, Pipeline]:
     di = data_ingestion()
     ci = company_info()
     cn = company_news()
+    st = strategies()
     return {
-        "__default__": di + ci + cn,
+        "__default__": di + ci + cn + st,
         "data_ingestion": di,
         "company_info": ci,
         "company_news": cn,
+        "strategies": st,
     }

--- a/src/rdd/pipelines/strategies/__init__.py
+++ b/src/rdd/pipelines/strategies/__init__.py
@@ -1,0 +1,1 @@
+"""Strategies pipeline — computes per-ticker trading signals from ingested data."""

--- a/src/rdd/pipelines/strategies/models.py
+++ b/src/rdd/pipelines/strategies/models.py
@@ -1,0 +1,38 @@
+"""Strategy output data models."""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+
+@dataclass
+class StrategySignal:
+    """A single strategy verdict for one ticker."""
+
+    strategy: str
+    direction: Literal["bullish", "bearish", "neutral"]
+    metrics: dict[str, Any]
+
+
+@dataclass
+class StockAnalysis:
+    """Aggregated strategy signals for one ticker."""
+
+    ticker: str
+    signals: list[StrategySignal]
+    generated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "ticker": self.ticker,
+            "generated_at": self.generated_at.isoformat(),
+            "signals": [
+                {
+                    "strategy": s.strategy,
+                    "direction": s.direction,
+                    "metrics": s.metrics,
+                }
+                for s in self.signals
+            ],
+        }

--- a/src/rdd/pipelines/strategies/nodes.py
+++ b/src/rdd/pipelines/strategies/nodes.py
@@ -1,0 +1,216 @@
+"""Strategy signal computation nodes."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pandas as pd
+
+from rdd.pipelines.strategies.models import StockAnalysis, StrategySignal
+
+
+def compute_momentum_signals(
+    ohlcv: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> dict[str, StrategySignal]:
+    """Compute price-return momentum signals over configurable lookback windows.
+
+    Direction is bullish when at least ``momentum_min_bullish`` windows show a
+    positive return, bearish when fewer than ``total - momentum_min_bullish``
+    windows are positive, and neutral otherwise.
+
+    Args:
+        ohlcv: Partitioned OHLCV dataset, keyed by lowercase ticker symbol.
+        params: Strategy parameters (see ``params_strategies.yml``).
+
+    Returns:
+        Mapping of ticker key to momentum ``StrategySignal``.
+    """
+    windows: dict[str, int] = params.get(
+        "momentum_windows", {"1m": 21, "3m": 63, "6m": 126, "12m": 252}
+    )
+    min_bullish: int = params.get("momentum_min_bullish", 3)
+    signals: dict[str, StrategySignal] = {}
+
+    for ticker_key, loader in ohlcv.items():
+        df = loader().sort_values("date")
+        prices = df["adj_close"].dropna()
+        if len(prices) < 2:
+            continue
+
+        metrics: dict[str, Any] = {}
+        positive_count = 0
+        total = 0
+
+        for label, days in windows.items():
+            if len(prices) > days:
+                ret = round(float(prices.iloc[-1] / prices.iloc[-days] - 1), 4)
+                metrics[f"return_{label}"] = ret
+                if ret > 0:
+                    positive_count += 1
+                total += 1
+
+        if total == 0:
+            continue
+
+        if positive_count >= min_bullish:
+            direction = "bullish"
+        elif positive_count <= total - min_bullish:
+            direction = "bearish"
+        else:
+            direction = "neutral"
+
+        signals[ticker_key] = StrategySignal(
+            strategy="momentum", direction=direction, metrics=metrics
+        )
+
+    return signals
+
+
+def compute_trend_signals(
+    ohlcv: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> dict[str, StrategySignal]:
+    """Compute moving-average trend signals (golden / death cross).
+
+    When both MAs are available, direction follows the MA cross: bullish on a
+    golden cross (short > long), bearish on a death cross. When only the short
+    MA is available, direction follows price vs. short MA.
+
+    Args:
+        ohlcv: Partitioned OHLCV dataset, keyed by lowercase ticker symbol.
+        params: Strategy parameters (see ``params_strategies.yml``).
+
+    Returns:
+        Mapping of ticker key to trend ``StrategySignal``.
+    """
+    short_window: int = params.get("trend_short_window", 50)
+    long_window: int = params.get("trend_long_window", 200)
+    signals: dict[str, StrategySignal] = {}
+
+    for ticker_key, loader in ohlcv.items():
+        df = loader().sort_values("date")
+        prices = df["adj_close"].dropna()
+        if len(prices) < short_window:
+            continue
+
+        ma_short = float(prices.rolling(short_window).mean().iloc[-1])
+        price = float(prices.iloc[-1])
+        price_vs_short_pct = round((price / ma_short - 1), 4)
+
+        metrics: dict[str, Any] = {
+            f"ma{short_window}": round(ma_short, 2),
+            "price_vs_ma_short_pct": price_vs_short_pct,
+        }
+
+        if len(prices) >= long_window:
+            ma_long = float(prices.rolling(long_window).mean().iloc[-1])
+            metrics[f"ma{long_window}"] = round(ma_long, 2)
+            metrics["cross"] = "golden" if ma_short > ma_long else "death"
+            direction = "bullish" if ma_short > ma_long else "bearish"
+        else:
+            direction = "bullish" if price_vs_short_pct > 0 else "bearish"
+
+        signals[ticker_key] = StrategySignal(
+            strategy="trend", direction=direction, metrics=metrics
+        )
+
+    return signals
+
+
+def compute_mean_reversion_signals(
+    ohlcv: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> dict[str, StrategySignal]:
+    """Compute mean-reversion signals via RSI and Bollinger Bands.
+
+    RSI below ``rsi_oversold`` signals a bullish (oversold) condition; above
+    ``rsi_overbought`` signals bearish (overbought). Bollinger Band position
+    is reported as a 0-1 fraction (0 = lower band, 1 = upper band).
+
+    Args:
+        ohlcv: Partitioned OHLCV dataset, keyed by lowercase ticker symbol.
+        params: Strategy parameters (see ``params_strategies.yml``).
+
+    Returns:
+        Mapping of ticker key to mean-reversion ``StrategySignal``.
+    """
+    rsi_window: int = params.get("rsi_window", 14)
+    rsi_oversold: float = params.get("rsi_oversold", 30.0)
+    rsi_overbought: float = params.get("rsi_overbought", 70.0)
+    bb_window: int = params.get("bb_window", 20)
+    bb_std: float = params.get("bb_std", 2.0)
+    signals: dict[str, StrategySignal] = {}
+
+    for ticker_key, loader in ohlcv.items():
+        df = loader().sort_values("date")
+        prices = df["adj_close"].dropna()
+        if len(prices) < max(rsi_window + 1, bb_window):
+            continue
+
+        # RSI via simple rolling averages
+        delta = prices.diff()
+        avg_gain = delta.clip(lower=0).rolling(rsi_window).mean()
+        avg_loss = (-delta.clip(upper=0)).rolling(rsi_window).mean()
+        # avg_loss=0 means pure gains → RS → ∞ → RSI → 100; avoid div-by-zero
+        rs = avg_gain / avg_loss.replace(0, 1e-10)
+        rsi = float((100 - 100 / (1 + rs)).iloc[-1])
+
+        # Bollinger Bands
+        ma = float(prices.rolling(bb_window).mean().iloc[-1])
+        std = float(prices.rolling(bb_window).std().iloc[-1])
+        bb_upper = ma + bb_std * std
+        bb_lower = ma - bb_std * std
+        price = float(prices.iloc[-1])
+        band_width = bb_upper - bb_lower
+        bb_position = round((price - bb_lower) / band_width, 2) if band_width > 0 else 0.5
+
+        metrics: dict[str, Any] = {
+            f"rsi_{rsi_window}": round(rsi, 1),
+            "bb_position": bb_position,
+            "bb_upper": round(bb_upper, 2),
+            "bb_lower": round(bb_lower, 2),
+        }
+
+        if rsi < rsi_oversold:
+            direction = "bullish"
+        elif rsi > rsi_overbought:
+            direction = "bearish"
+        else:
+            direction = "neutral"
+
+        signals[ticker_key] = StrategySignal(
+            strategy="mean_reversion", direction=direction, metrics=metrics
+        )
+
+    return signals
+
+
+def assemble_stock_analyses(
+    momentum: dict[str, StrategySignal],
+    trend: dict[str, StrategySignal],
+    mean_reversion: dict[str, StrategySignal],
+) -> dict[str, dict[str, Any]]:
+    """Combine per-strategy signals into one ``StockAnalysis`` per ticker.
+
+    Args:
+        momentum: Momentum signals keyed by lowercase ticker.
+        trend: Trend signals keyed by lowercase ticker.
+        mean_reversion: Mean-reversion signals keyed by lowercase ticker.
+
+    Returns:
+        Mapping of lowercase ticker to serialised ``StockAnalysis`` dict,
+        ready for JSON persistence.
+    """
+    all_tickers = set(momentum) | set(trend) | set(mean_reversion)
+    result: dict[str, dict[str, Any]] = {}
+
+    for ticker_key in sorted(all_tickers):
+        signals = [
+            sig
+            for sig_map in (momentum, trend, mean_reversion)
+            if (sig := sig_map.get(ticker_key)) is not None
+        ]
+        analysis = StockAnalysis(ticker=ticker_key.upper(), signals=signals)
+        result[ticker_key] = analysis.to_dict()
+
+    return result

--- a/src/rdd/pipelines/strategies/nodes.py
+++ b/src/rdd/pipelines/strategies/nodes.py
@@ -3,7 +3,9 @@
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
 import pandas as pd
+from arch import arch_model
 
 from rdd.pipelines.strategies.models import StockAnalysis, StrategySignal
 
@@ -187,10 +189,83 @@ def compute_mean_reversion_signals(
     return signals
 
 
+def compute_volatility_signals(
+    ohlcv: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> dict[str, StrategySignal]:
+    """Fit a GARCH(1,1) model on log returns to estimate conditional volatility.
+
+    Produces a regime descriptor — not a directional bet. Direction is:
+    - ``"bearish"`` when current vol is elevated vs. long-run (vol_ratio > high threshold)
+    - ``"bullish"`` when vol is compressed vs. long-run (vol_ratio < low threshold)
+    - ``"neutral"`` otherwise
+
+    Args:
+        ohlcv: Partitioned OHLCV dataset, keyed by lowercase ticker symbol.
+        params: Strategy parameters (see ``params_strategies.yml``).
+
+    Returns:
+        Mapping of ticker key to volatility ``StrategySignal``.
+    """
+    min_obs: int = params.get("garch_min_obs", 252)
+    vol_high: float = params.get("garch_vol_ratio_high", 1.5)
+    vol_low: float = params.get("garch_vol_ratio_low", 0.75)
+    signals: dict[str, StrategySignal] = {}
+
+    for ticker_key, loader in ohlcv.items():
+        df = loader().sort_values("date")
+        prices = df["adj_close"].dropna()
+        if len(prices) < min_obs + 1:
+            continue
+
+        log_returns = np.log(prices / prices.shift(1)).dropna() * 100
+
+        try:
+            res = arch_model(log_returns, vol="Garch", p=1, q=1, rescale=False).fit(
+                disp="off"
+            )
+        except Exception:
+            continue
+
+        # Conditional vol for today (annualised %)
+        current_vol = float(np.sqrt(res.conditional_volatility.iloc[-1] ** 2 * 252))
+        # Long-run unconditional vol: omega / (1 - alpha - beta), annualised
+        omega = float(res.params["omega"])
+        alpha = float(res.params["alpha[1]"])
+        beta = float(res.params["beta[1]"])
+        persistence = round(alpha + beta, 4)
+        denom = 1 - alpha - beta
+        if denom <= 0:
+            continue
+        long_run_vol = float(np.sqrt(omega / denom * 252))
+        vol_ratio = round(current_vol / long_run_vol, 4) if long_run_vol > 0 else 1.0
+
+        if vol_ratio > vol_high:
+            direction = "bearish"
+        elif vol_ratio < vol_low:
+            direction = "bullish"
+        else:
+            direction = "neutral"
+
+        signals[ticker_key] = StrategySignal(
+            strategy="volatility",
+            direction=direction,
+            metrics={
+                "current_vol_ann": round(current_vol, 4),
+                "long_run_vol_ann": round(long_run_vol, 4),
+                "vol_ratio": vol_ratio,
+                "persistence": persistence,
+            },
+        )
+
+    return signals
+
+
 def assemble_stock_analyses(
     momentum: dict[str, StrategySignal],
     trend: dict[str, StrategySignal],
     mean_reversion: dict[str, StrategySignal],
+    volatility: dict[str, StrategySignal],
 ) -> dict[str, dict[str, Any]]:
     """Combine per-strategy signals into one ``StockAnalysis`` per ticker.
 
@@ -198,18 +273,19 @@ def assemble_stock_analyses(
         momentum: Momentum signals keyed by lowercase ticker.
         trend: Trend signals keyed by lowercase ticker.
         mean_reversion: Mean-reversion signals keyed by lowercase ticker.
+        volatility: GARCH volatility signals keyed by lowercase ticker.
 
     Returns:
         Mapping of lowercase ticker to serialised ``StockAnalysis`` dict,
         ready for JSON persistence.
     """
-    all_tickers = set(momentum) | set(trend) | set(mean_reversion)
+    all_tickers = set(momentum) | set(trend) | set(mean_reversion) | set(volatility)
     result: dict[str, dict[str, Any]] = {}
 
     for ticker_key in sorted(all_tickers):
         signals = [
             sig
-            for sig_map in (momentum, trend, mean_reversion)
+            for sig_map in (momentum, trend, mean_reversion, volatility)
             if (sig := sig_map.get(ticker_key)) is not None
         ]
         analysis = StockAnalysis(ticker=ticker_key.upper(), signals=signals)

--- a/src/rdd/pipelines/strategies/nodes.py
+++ b/src/rdd/pipelines/strategies/nodes.py
@@ -162,7 +162,9 @@ def compute_mean_reversion_signals(
         bb_lower = ma - bb_std * std
         price = float(prices.iloc[-1])
         band_width = bb_upper - bb_lower
-        bb_position = round((price - bb_lower) / band_width, 2) if band_width > 0 else 0.5
+        bb_position = (
+            round((price - bb_lower) / band_width, 2) if band_width > 0 else 0.5
+        )
 
         metrics: dict[str, Any] = {
             f"rsi_{rsi_window}": round(rsi, 1),

--- a/src/rdd/pipelines/strategies/pipeline.py
+++ b/src/rdd/pipelines/strategies/pipeline.py
@@ -1,0 +1,42 @@
+"""Strategies pipeline — derives trading signals from ingested OHLCV data."""
+
+from kedro.pipeline import Pipeline, node
+
+from rdd.pipelines.strategies.nodes import (
+    assemble_stock_analyses,
+    compute_mean_reversion_signals,
+    compute_momentum_signals,
+    compute_trend_signals,
+)
+
+
+def create_pipeline(**_kwargs) -> Pipeline:
+    """Create the strategies pipeline."""
+    return Pipeline(
+        nodes=[
+            node(
+                func=compute_momentum_signals,
+                inputs=["raw_ohlcv", "params:strategies"],
+                outputs="momentum_signals",
+                name="compute_momentum_signals",
+            ),
+            node(
+                func=compute_trend_signals,
+                inputs=["raw_ohlcv", "params:strategies"],
+                outputs="trend_signals",
+                name="compute_trend_signals",
+            ),
+            node(
+                func=compute_mean_reversion_signals,
+                inputs=["raw_ohlcv", "params:strategies"],
+                outputs="mean_reversion_signals",
+                name="compute_mean_reversion_signals",
+            ),
+            node(
+                func=assemble_stock_analyses,
+                inputs=["momentum_signals", "trend_signals", "mean_reversion_signals"],
+                outputs="stock_analyses",
+                name="assemble_stock_analyses",
+            ),
+        ]
+    )

--- a/src/rdd/pipelines/strategies/pipeline.py
+++ b/src/rdd/pipelines/strategies/pipeline.py
@@ -7,6 +7,7 @@ from rdd.pipelines.strategies.nodes import (
     compute_mean_reversion_signals,
     compute_momentum_signals,
     compute_trend_signals,
+    compute_volatility_signals,
 )
 
 
@@ -33,8 +34,19 @@ def create_pipeline(**_kwargs) -> Pipeline:
                 name="compute_mean_reversion_signals",
             ),
             node(
+                func=compute_volatility_signals,
+                inputs=["raw_ohlcv", "params:strategies"],
+                outputs="volatility_signals",
+                name="compute_volatility_signals",
+            ),
+            node(
                 func=assemble_stock_analyses,
-                inputs=["momentum_signals", "trend_signals", "mean_reversion_signals"],
+                inputs=[
+                    "momentum_signals",
+                    "trend_signals",
+                    "mean_reversion_signals",
+                    "volatility_signals",
+                ],
                 outputs="stock_analyses",
                 name="assemble_stock_analyses",
             ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,3 +86,28 @@ def make_company_news_df(
 def company_news_df() -> pd.DataFrame:
     """Three-row company news DataFrame that satisfies CompanyNewsSchema (AAPL)."""
     return make_company_news_df()
+
+
+def make_price_ohlcv(
+    prices: list[float],
+    ticker: str = "AAPL",
+    start: str = "2024-01-02",
+) -> pd.DataFrame:
+    """Return an OHLCV DataFrame driven by an explicit *prices* list.
+
+    Suitable for strategy tests that need controlled price trajectories (trends,
+    RSI scenarios) without going through the Pandera example generator.
+    """
+    n = len(prices)
+    return pd.DataFrame(
+        {
+            "ticker": [ticker] * n,
+            "date": pd.date_range(start, periods=n, freq="B"),
+            "adj_close": prices,
+            "close": prices,
+            "open": [p * 1.005 for p in prices],
+            "high": [p * 1.01 for p in prices],
+            "low": [p * 0.99 for p in prices],
+            "volume": [1_000_000.0] * n,
+        }
+    )

--- a/tests/pipelines/strategies/__init__.py
+++ b/tests/pipelines/strategies/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the strategies pipeline."""

--- a/tests/pipelines/strategies/test_nodes.py
+++ b/tests/pipelines/strategies/test_nodes.py
@@ -1,0 +1,265 @@
+"""Unit tests for strategies pipeline nodes.
+
+Each node is tested in isolation with synthetic price series designed to
+produce unambiguous signal directions, so test intent is self-evident from
+the data rather than from magic expected values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pandas as pd
+import pytest
+
+from rdd.pipelines.strategies.models import StrategySignal
+from rdd.pipelines.strategies.nodes import (
+    assemble_stock_analyses,
+    compute_mean_reversion_signals,
+    compute_momentum_signals,
+    compute_trend_signals,
+)
+from tests.conftest import make_price_ohlcv
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_UPTREND = [100.0 + i * 0.5 for i in range(260)]   # 260 days, steadily rising
+_DOWNTREND = [230.0 - i * 0.5 for i in range(260)]  # 260 days, steadily falling
+
+
+def _ohlcv(df: pd.DataFrame, key: str = "aapl") -> dict[str, Callable[[], pd.DataFrame]]:
+    return {key: lambda _df=df: _df}
+
+
+@pytest.fixture
+def params() -> dict:
+    return {
+        "momentum_windows": {"1m": 21, "3m": 63, "6m": 126, "12m": 252},
+        "momentum_min_bullish": 3,
+        "trend_short_window": 50,
+        "trend_long_window": 200,
+        "rsi_window": 14,
+        "rsi_oversold": 30.0,
+        "rsi_overbought": 70.0,
+        "bb_window": 20,
+        "bb_std": 2.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# compute_momentum_signals
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMomentumSignals:
+    def test_uptrend_is_bullish(self, params) -> None:
+        result = compute_momentum_signals(_ohlcv(make_price_ohlcv(_UPTREND)), params)
+
+        assert result["aapl"].direction == "bullish"
+
+    def test_downtrend_is_bearish(self, params) -> None:
+        result = compute_momentum_signals(_ohlcv(make_price_ohlcv(_DOWNTREND)), params)
+
+        assert result["aapl"].direction == "bearish"
+
+    def test_metrics_contain_all_four_windows(self, params) -> None:
+        result = compute_momentum_signals(_ohlcv(make_price_ohlcv(_UPTREND)), params)
+
+        assert set(result["aapl"].metrics.keys()) == {
+            "return_1m",
+            "return_3m",
+            "return_6m",
+            "return_12m",
+        }
+
+    def test_short_series_only_emits_available_windows(self, params) -> None:
+        # 30 rows → only 1m (21d) window fits; 3m/6m/12m are skipped
+        prices = [100.0 + i * 0.5 for i in range(30)]
+        result = compute_momentum_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert "return_1m" in result["aapl"].metrics
+        assert "return_3m" not in result["aapl"].metrics
+
+    def test_single_row_ticker_is_skipped(self, params) -> None:
+        result = compute_momentum_signals(_ohlcv(make_price_ohlcv([100.0])), params)
+
+        assert "aapl" not in result
+
+    def test_multiple_tickers_are_independent(self, params) -> None:
+        ohlcv = {
+            "aapl": lambda: make_price_ohlcv(_UPTREND, ticker="AAPL"),
+            "msft": lambda: make_price_ohlcv(_DOWNTREND, ticker="MSFT"),
+        }
+        result = compute_momentum_signals(ohlcv, params)
+
+        assert result["aapl"].direction == "bullish"
+        assert result["msft"].direction == "bearish"
+
+
+# ---------------------------------------------------------------------------
+# compute_trend_signals
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTrendSignals:
+    def test_golden_cross_is_bullish(self, params) -> None:
+        # Uptrend → MA50 > MA200 → golden cross
+        result = compute_trend_signals(_ohlcv(make_price_ohlcv(_UPTREND)), params)
+
+        assert result["aapl"].direction == "bullish"
+        assert result["aapl"].metrics.get("cross") == "golden"
+
+    def test_death_cross_is_bearish(self, params) -> None:
+        result = compute_trend_signals(_ohlcv(make_price_ohlcv(_DOWNTREND)), params)
+
+        assert result["aapl"].direction == "bearish"
+        assert result["aapl"].metrics.get("cross") == "death"
+
+    def test_short_series_uses_price_vs_ma50(self, params) -> None:
+        # 60 rows: MA50 available, MA200 not — direction follows price vs MA50
+        prices = [100.0 + i * 0.5 for i in range(60)]  # rising → price > MA50
+        result = compute_trend_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert result["aapl"].direction == "bullish"
+        assert "cross" not in result["aapl"].metrics
+        assert "ma200" not in result["aapl"].metrics
+
+    def test_insufficient_data_ticker_is_skipped(self, params) -> None:
+        prices = [100.0 + i for i in range(10)]
+        result = compute_trend_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert "aapl" not in result
+
+    def test_metrics_contain_ma_values(self, params) -> None:
+        result = compute_trend_signals(_ohlcv(make_price_ohlcv(_UPTREND)), params)
+        metrics = result["aapl"].metrics
+
+        assert "ma50" in metrics
+        assert "ma200" in metrics
+        assert "price_vs_ma_short_pct" in metrics
+
+
+# ---------------------------------------------------------------------------
+# compute_mean_reversion_signals
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMeanReversionSignals:
+    def test_declining_prices_are_oversold_bullish(self, params) -> None:
+        # Pure decline → RSI ≈ 0 (< 30) → bullish
+        prices = [200.0 - i * 2.0 for i in range(30)]
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert result["aapl"].direction == "bullish"
+        assert result["aapl"].metrics[f"rsi_{params['rsi_window']}"] < 30
+
+    def test_rising_prices_are_overbought_bearish(self, params) -> None:
+        # Pure rise → RSI ≈ 100 (> 70) → bearish
+        prices = [100.0 + i * 2.0 for i in range(30)]
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert result["aapl"].direction == "bearish"
+        assert result["aapl"].metrics[f"rsi_{params['rsi_window']}"] > 70
+
+    def test_alternating_prices_are_neutral(self, params) -> None:
+        # Equal up/down moves → RSI ≈ 50 → neutral
+        prices = [100.0 + (1.0 if i % 2 == 0 else -1.0) * (i // 2 + 1) for i in range(30)]
+        # Simpler: fixed alternating deltas from a constant base
+        base = 100.0
+        prices = []
+        for i in range(30):
+            base += 1.0 if i % 2 == 0 else -1.0
+            prices.append(base)
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert result["aapl"].direction == "neutral"
+
+    def test_insufficient_data_ticker_is_skipped(self, params) -> None:
+        prices = [100.0 + i for i in range(5)]
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        assert "aapl" not in result
+
+    def test_metrics_contain_bb_and_rsi(self, params) -> None:
+        prices = [200.0 - i * 2.0 for i in range(30)]
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+        metrics = result["aapl"].metrics
+
+        assert f"rsi_{params['rsi_window']}" in metrics
+        assert "bb_position" in metrics
+        assert "bb_upper" in metrics
+        assert "bb_lower" in metrics
+
+    def test_bb_position_within_zero_one(self, params) -> None:
+        prices = [100.0 + i * 0.1 for i in range(30)]
+        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+
+        bb_pos = result["aapl"].metrics["bb_position"]
+        assert 0.0 <= bb_pos <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# assemble_stock_analyses
+# ---------------------------------------------------------------------------
+
+
+def _make_signal(strategy: str) -> StrategySignal:
+    return StrategySignal(strategy=strategy, direction="bullish", metrics={})
+
+
+class TestAssembleStockAnalyses:
+    def test_output_contains_all_tickers(self) -> None:
+        momentum = {"aapl": _make_signal("momentum"), "msft": _make_signal("momentum")}
+        trend = {"aapl": _make_signal("trend"), "msft": _make_signal("trend")}
+        mean_rev = {"aapl": _make_signal("mean_reversion")}
+
+        result = assemble_stock_analyses(momentum, trend, mean_rev)
+
+        assert "aapl" in result
+        assert "msft" in result
+
+    def test_ticker_is_uppercased_in_output(self) -> None:
+        signal = {"aapl": _make_signal("momentum")}
+        result = assemble_stock_analyses(signal, {}, {})
+
+        assert result["aapl"]["ticker"] == "AAPL"
+
+    def test_all_three_strategy_signals_present(self) -> None:
+        sig = {"aapl": _make_signal("momentum")}
+        trend = {"aapl": _make_signal("trend")}
+        mean_rev = {"aapl": _make_signal("mean_reversion")}
+
+        result = assemble_stock_analyses(sig, trend, mean_rev)
+        strategies = {s["strategy"] for s in result["aapl"]["signals"]}
+
+        assert strategies == {"momentum", "trend", "mean_reversion"}
+
+    def test_missing_strategy_excluded_from_signals(self) -> None:
+        # mean_reversion skipped ticker (e.g. insufficient data)
+        result = assemble_stock_analyses(
+            {"aapl": _make_signal("momentum")},
+            {"aapl": _make_signal("trend")},
+            {},
+        )
+
+        strategies = {s["strategy"] for s in result["aapl"]["signals"]}
+        assert "mean_reversion" not in strategies
+        assert len(result["aapl"]["signals"]) == 2
+
+    def test_output_has_required_top_level_keys(self) -> None:
+        result = assemble_stock_analyses({"aapl": _make_signal("momentum")}, {}, {})
+        entry = result["aapl"]
+
+        assert {"ticker", "generated_at", "signals"} <= entry.keys()
+
+    def test_tickers_are_sorted_in_output(self) -> None:
+        signals = {
+            "msft": _make_signal("momentum"),
+            "aapl": _make_signal("momentum"),
+            "goog": _make_signal("momentum"),
+        }
+        result = assemble_stock_analyses(signals, {}, {})
+
+        assert list(result.keys()) == sorted(result.keys())

--- a/tests/pipelines/strategies/test_nodes.py
+++ b/tests/pipelines/strategies/test_nodes.py
@@ -25,11 +25,13 @@ from tests.conftest import make_price_ohlcv
 # Shared helpers
 # ---------------------------------------------------------------------------
 
-_UPTREND = [100.0 + i * 0.5 for i in range(260)]   # 260 days, steadily rising
+_UPTREND = [100.0 + i * 0.5 for i in range(260)]  # 260 days, steadily rising
 _DOWNTREND = [230.0 - i * 0.5 for i in range(260)]  # 260 days, steadily falling
 
 
-def _ohlcv(df: pd.DataFrame, key: str = "aapl") -> dict[str, Callable[[], pd.DataFrame]]:
+def _ohlcv(
+    df: pd.DataFrame, key: str = "aapl"
+) -> dict[str, Callable[[], pd.DataFrame]]:
     return {key: lambda _df=df: _df}
 
 
@@ -150,7 +152,9 @@ class TestComputeMeanReversionSignals:
     def test_declining_prices_are_oversold_bullish(self, params) -> None:
         # Pure decline → RSI ≈ 0 (< 30) → bullish
         prices = [200.0 - i * 2.0 for i in range(30)]
-        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+        result = compute_mean_reversion_signals(
+            _ohlcv(make_price_ohlcv(prices)), params
+        )
 
         assert result["aapl"].direction == "bullish"
         assert result["aapl"].metrics[f"rsi_{params['rsi_window']}"] < 30
@@ -158,33 +162,43 @@ class TestComputeMeanReversionSignals:
     def test_rising_prices_are_overbought_bearish(self, params) -> None:
         # Pure rise → RSI ≈ 100 (> 70) → bearish
         prices = [100.0 + i * 2.0 for i in range(30)]
-        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+        result = compute_mean_reversion_signals(
+            _ohlcv(make_price_ohlcv(prices)), params
+        )
 
         assert result["aapl"].direction == "bearish"
         assert result["aapl"].metrics[f"rsi_{params['rsi_window']}"] > 70
 
     def test_alternating_prices_are_neutral(self, params) -> None:
         # Equal up/down moves → RSI ≈ 50 → neutral
-        prices = [100.0 + (1.0 if i % 2 == 0 else -1.0) * (i // 2 + 1) for i in range(30)]
+        prices = [
+            100.0 + (1.0 if i % 2 == 0 else -1.0) * (i // 2 + 1) for i in range(30)
+        ]
         # Simpler: fixed alternating deltas from a constant base
         base = 100.0
         prices = []
         for i in range(30):
             base += 1.0 if i % 2 == 0 else -1.0
             prices.append(base)
-        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+        result = compute_mean_reversion_signals(
+            _ohlcv(make_price_ohlcv(prices)), params
+        )
 
         assert result["aapl"].direction == "neutral"
 
     def test_insufficient_data_ticker_is_skipped(self, params) -> None:
         prices = [100.0 + i for i in range(5)]
-        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+        result = compute_mean_reversion_signals(
+            _ohlcv(make_price_ohlcv(prices)), params
+        )
 
         assert "aapl" not in result
 
     def test_metrics_contain_bb_and_rsi(self, params) -> None:
         prices = [200.0 - i * 2.0 for i in range(30)]
-        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+        result = compute_mean_reversion_signals(
+            _ohlcv(make_price_ohlcv(prices)), params
+        )
         metrics = result["aapl"].metrics
 
         assert f"rsi_{params['rsi_window']}" in metrics
@@ -194,7 +208,9 @@ class TestComputeMeanReversionSignals:
 
     def test_bb_position_within_zero_one(self, params) -> None:
         prices = [100.0 + i * 0.1 for i in range(30)]
-        result = compute_mean_reversion_signals(_ohlcv(make_price_ohlcv(prices)), params)
+        result = compute_mean_reversion_signals(
+            _ohlcv(make_price_ohlcv(prices)), params
+        )
 
         bb_pos = result["aapl"].metrics["bb_position"]
         assert 0.0 <= bb_pos <= 1.0

--- a/tests/pipelines/strategies/test_nodes.py
+++ b/tests/pipelines/strategies/test_nodes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -18,6 +19,7 @@ from rdd.pipelines.strategies.nodes import (
     compute_mean_reversion_signals,
     compute_momentum_signals,
     compute_trend_signals,
+    compute_volatility_signals,
 )
 from tests.conftest import make_price_ohlcv
 
@@ -217,6 +219,75 @@ class TestComputeMeanReversionSignals:
 
 
 # ---------------------------------------------------------------------------
+# compute_volatility_signals
+# ---------------------------------------------------------------------------
+
+# 300 days of realistic-looking prices for GARCH to fit — fixed seed for determinism
+_rng = np.random.default_rng(42)
+_GARCH_PRICES = list(100.0 * np.exp(np.cumsum(_rng.normal(0, 0.01, 300))))
+
+
+class TestComputeVolatilitySignals:
+    @pytest.fixture
+    def params(self) -> dict:
+        return {
+            "garch_min_obs": 252,
+            "garch_vol_ratio_high": 1.5,
+            "garch_vol_ratio_low": 0.75,
+        }
+
+    def test_returns_signal_for_sufficient_data(self, params) -> None:
+        result = compute_volatility_signals(
+            _ohlcv(make_price_ohlcv(_GARCH_PRICES)), params
+        )
+
+        assert "aapl" in result
+        assert isinstance(result["aapl"], StrategySignal)
+        assert result["aapl"].strategy == "volatility"
+
+    def test_direction_is_valid(self, params) -> None:
+        result = compute_volatility_signals(
+            _ohlcv(make_price_ohlcv(_GARCH_PRICES)), params
+        )
+
+        assert result["aapl"].direction in {"bullish", "bearish", "neutral"}
+
+    def test_metrics_contain_required_keys(self, params) -> None:
+        result = compute_volatility_signals(
+            _ohlcv(make_price_ohlcv(_GARCH_PRICES)), params
+        )
+        metrics = result["aapl"].metrics
+
+        assert "current_vol_ann" in metrics
+        assert "long_run_vol_ann" in metrics
+        assert "vol_ratio" in metrics
+        assert "persistence" in metrics
+
+    def test_persistence_between_zero_and_one(self, params) -> None:
+        result = compute_volatility_signals(
+            _ohlcv(make_price_ohlcv(_GARCH_PRICES)), params
+        )
+
+        persistence = result["aapl"].metrics["persistence"]
+        assert 0.0 <= persistence < 1.0
+
+    def test_vol_ratio_positive(self, params) -> None:
+        result = compute_volatility_signals(
+            _ohlcv(make_price_ohlcv(_GARCH_PRICES)), params
+        )
+
+        assert result["aapl"].metrics["vol_ratio"] > 0
+
+    def test_skips_ticker_with_insufficient_data(self, params) -> None:
+        short_prices = [100.0 + i * 0.1 for i in range(100)]
+        result = compute_volatility_signals(
+            _ohlcv(make_price_ohlcv(short_prices)), params
+        )
+
+        assert "aapl" not in result
+
+
+# ---------------------------------------------------------------------------
 # assemble_stock_analyses
 # ---------------------------------------------------------------------------
 
@@ -231,41 +302,44 @@ class TestAssembleStockAnalyses:
         trend = {"aapl": _make_signal("trend"), "msft": _make_signal("trend")}
         mean_rev = {"aapl": _make_signal("mean_reversion")}
 
-        result = assemble_stock_analyses(momentum, trend, mean_rev)
+        result = assemble_stock_analyses(momentum, trend, mean_rev, {})
 
         assert "aapl" in result
         assert "msft" in result
 
     def test_ticker_is_uppercased_in_output(self) -> None:
         signal = {"aapl": _make_signal("momentum")}
-        result = assemble_stock_analyses(signal, {}, {})
+        result = assemble_stock_analyses(signal, {}, {}, {})
 
         assert result["aapl"]["ticker"] == "AAPL"
 
-    def test_all_three_strategy_signals_present(self) -> None:
-        sig = {"aapl": _make_signal("momentum")}
-        trend = {"aapl": _make_signal("trend")}
-        mean_rev = {"aapl": _make_signal("mean_reversion")}
-
-        result = assemble_stock_analyses(sig, trend, mean_rev)
-        strategies = {s["strategy"] for s in result["aapl"]["signals"]}
-
-        assert strategies == {"momentum", "trend", "mean_reversion"}
-
-    def test_missing_strategy_excluded_from_signals(self) -> None:
-        # mean_reversion skipped ticker (e.g. insufficient data)
+    def test_all_four_strategy_signals_present(self) -> None:
         result = assemble_stock_analyses(
             {"aapl": _make_signal("momentum")},
             {"aapl": _make_signal("trend")},
+            {"aapl": _make_signal("mean_reversion")},
+            {"aapl": _make_signal("volatility")},
+        )
+        strategies = {s["strategy"] for s in result["aapl"]["signals"]}
+
+        assert strategies == {"momentum", "trend", "mean_reversion", "volatility"}
+
+    def test_missing_strategy_excluded_from_signals(self) -> None:
+        # volatility skipped ticker (e.g. insufficient data for GARCH)
+        result = assemble_stock_analyses(
+            {"aapl": _make_signal("momentum")},
+            {"aapl": _make_signal("trend")},
+            {},
             {},
         )
 
         strategies = {s["strategy"] for s in result["aapl"]["signals"]}
         assert "mean_reversion" not in strategies
+        assert "volatility" not in strategies
         assert len(result["aapl"]["signals"]) == 2
 
     def test_output_has_required_top_level_keys(self) -> None:
-        result = assemble_stock_analyses({"aapl": _make_signal("momentum")}, {}, {})
+        result = assemble_stock_analyses({"aapl": _make_signal("momentum")}, {}, {}, {})
         entry = result["aapl"]
 
         assert {"ticker", "generated_at", "signals"} <= entry.keys()
@@ -276,6 +350,6 @@ class TestAssembleStockAnalyses:
             "aapl": _make_signal("momentum"),
             "goog": _make_signal("momentum"),
         }
-        result = assemble_stock_analyses(signals, {}, {})
+        result = assemble_stock_analyses(signals, {}, {}, {})
 
         assert list(result.keys()) == sorted(result.keys())

--- a/tests/pipelines/strategies/test_pipeline.py
+++ b/tests/pipelines/strategies/test_pipeline.py
@@ -36,6 +36,9 @@ def params() -> dict:
         "rsi_overbought": 70.0,
         "bb_window": 20,
         "bb_std": 2.0,
+        "garch_min_obs": 252,
+        "garch_vol_ratio_high": 1.5,
+        "garch_vol_ratio_low": 0.75,
     }
 
 
@@ -56,6 +59,7 @@ def catalog(params) -> DataCatalog:
             "momentum_signals": MemoryDataset(),
             "trend_signals": MemoryDataset(),
             "mean_reversion_signals": MemoryDataset(),
+            "volatility_signals": MemoryDataset(),
             "stock_analyses": MemoryDataset(),
         }
     )
@@ -93,13 +97,13 @@ def test_pipeline_output_structure(pipeline, catalog) -> None:
             assert signal["direction"] in {"bullish", "bearish", "neutral"}
 
 
-def test_pipeline_emits_all_three_strategies(pipeline, catalog) -> None:
+def test_pipeline_emits_all_four_strategies(pipeline, catalog) -> None:
     SequentialRunner().run(pipeline, catalog)
 
     result = catalog.load("stock_analyses")
     for entry in result.values():
         strategies = {s["strategy"] for s in entry["signals"]}
-        assert strategies == {"momentum", "trend", "mean_reversion"}
+        assert strategies == {"momentum", "trend", "mean_reversion", "volatility"}
 
 
 def test_pipeline_ticker_is_uppercase(pipeline, catalog) -> None:
@@ -127,6 +131,7 @@ def test_pipeline_skips_tickers_with_insufficient_data(pipeline, params) -> None
             "momentum_signals": MemoryDataset(),
             "trend_signals": MemoryDataset(),
             "mean_reversion_signals": MemoryDataset(),
+            "volatility_signals": MemoryDataset(),
             "stock_analyses": MemoryDataset(),
         }
     )

--- a/tests/pipelines/strategies/test_pipeline.py
+++ b/tests/pipelines/strategies/test_pipeline.py
@@ -1,0 +1,138 @@
+"""Integration tests for the strategies pipeline.
+
+Runs the full strategies pipeline (momentum → trend → mean_reversion →
+assemble) via SequentialRunner with a fully in-memory DataCatalog.
+No network calls, no filesystem I/O.
+"""
+
+from __future__ import annotations
+
+import pytest
+from kedro.io import DataCatalog, MemoryDataset
+from kedro.runner import SequentialRunner
+
+from rdd.pipelines.strategies.pipeline import create_pipeline
+from tests.conftest import make_price_ohlcv
+
+_UPTREND = [100.0 + i * 0.5 for i in range(260)]
+_DOWNTREND = [230.0 - i * 0.5 for i in range(260)]
+
+
+@pytest.fixture
+def pipeline():
+    """The strategies Kedro pipeline."""
+    return create_pipeline()
+
+
+@pytest.fixture
+def params() -> dict:
+    return {
+        "momentum_windows": {"1m": 21, "3m": 63, "6m": 126, "12m": 252},
+        "momentum_min_bullish": 3,
+        "trend_short_window": 50,
+        "trend_long_window": 200,
+        "rsi_window": 14,
+        "rsi_oversold": 30.0,
+        "rsi_overbought": 70.0,
+        "bb_window": 20,
+        "bb_std": 2.0,
+    }
+
+
+@pytest.fixture
+def catalog(params) -> DataCatalog:
+    """In-memory catalog with two tickers of sufficient history."""
+    aapl_df = make_price_ohlcv(_UPTREND, ticker="AAPL")
+    msft_df = make_price_ohlcv(_DOWNTREND, ticker="MSFT")
+    return DataCatalog(
+        {
+            "params:strategies": MemoryDataset(data=params),
+            "raw_ohlcv": MemoryDataset(
+                data={
+                    "aapl": lambda: aapl_df,
+                    "msft": lambda: msft_df,
+                }
+            ),
+            "momentum_signals": MemoryDataset(),
+            "trend_signals": MemoryDataset(),
+            "mean_reversion_signals": MemoryDataset(),
+            "stock_analyses": MemoryDataset(),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_runs_without_error(pipeline, catalog) -> None:
+    """Full pipeline executes end-to-end without raising."""
+    SequentialRunner().run(pipeline, catalog)
+
+
+def test_pipeline_produces_stock_analyses(pipeline, catalog) -> None:
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("stock_analyses")
+    assert isinstance(result, dict)
+    assert len(result) == 2
+    assert "aapl" in result
+    assert "msft" in result
+
+
+def test_pipeline_output_structure(pipeline, catalog) -> None:
+    """Each entry has the expected top-level keys and signal list shape."""
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("stock_analyses")
+    for entry in result.values():
+        assert {"ticker", "generated_at", "signals"} <= entry.keys()
+        for signal in entry["signals"]:
+            assert {"strategy", "direction", "metrics"} <= signal.keys()
+            assert signal["direction"] in {"bullish", "bearish", "neutral"}
+
+
+def test_pipeline_emits_all_three_strategies(pipeline, catalog) -> None:
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("stock_analyses")
+    for entry in result.values():
+        strategies = {s["strategy"] for s in entry["signals"]}
+        assert strategies == {"momentum", "trend", "mean_reversion"}
+
+
+def test_pipeline_ticker_is_uppercase(pipeline, catalog) -> None:
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("stock_analyses")
+    assert result["aapl"]["ticker"] == "AAPL"
+    assert result["msft"]["ticker"] == "MSFT"
+
+
+def test_pipeline_skips_tickers_with_insufficient_data(pipeline, params) -> None:
+    """A ticker with only 5 rows produces no signals but does not crash."""
+    short_df = make_price_ohlcv([100.0 + i for i in range(5)], ticker="SHORT")
+    full_df = make_price_ohlcv(_UPTREND, ticker="AAPL")
+
+    catalog = DataCatalog(
+        {
+            "params:strategies": MemoryDataset(data=params),
+            "raw_ohlcv": MemoryDataset(
+                data={
+                    "aapl": lambda: full_df,
+                    "short": lambda: short_df,
+                }
+            ),
+            "momentum_signals": MemoryDataset(),
+            "trend_signals": MemoryDataset(),
+            "mean_reversion_signals": MemoryDataset(),
+            "stock_analyses": MemoryDataset(),
+        }
+    )
+
+    SequentialRunner().run(pipeline, catalog)
+
+    result = catalog.load("stock_analyses")
+    assert "aapl" in result
+    assert "short" not in result

--- a/tests/scripts/test_run_daily_ingest.py
+++ b/tests/scripts/test_run_daily_ingest.py
@@ -2,7 +2,7 @@ import subprocess
 from pathlib import Path
 
 SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "run_daily_ingest.sh"
-PIPELINES = ["data_ingestion", "company_info", "company_news"]
+PIPELINES = ["data_ingestion", "company_info", "company_news", "strategies"]
 
 
 def test_dry_run_exits_zero():

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,33 @@ wheels = [
 ]
 
 [[package]]
+name = "arch"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "statsmodels" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/50/f8be4b21db5eb0490aef82b592d105baac957f601805ee7fe5b9182405b2/arch-8.0.0.tar.gz", hash = "sha256:5e9895c2354b9475aff50797ff2191dc64dc5f79602baf0c9321310fb864b637", size = 872623, upload-time = "2025-10-21T08:55:52.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/51/78f84f9e486e173356931b2bfaf0c2a6d6923f1e8975045e3416ac388215/arch-8.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4320a9b3707e819a97f0b0a10847e529e2f765158c617a455987a34305018617", size = 940530, upload-time = "2025-10-21T08:46:04.53Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b8/73910773efffc2d35d2739be1bdc70dfcc58a83cff35c4d62e14acceca2b/arch-8.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6b75bc7f4af4da5aca6cbcc52284564fcce8c974cf7d89d8b9777d8c16a228b0", size = 930359, upload-time = "2025-10-21T08:40:11.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/04/bdd65c773f6ce60cae50cb4f85bcf15dcbe687df75998966e5a236125182/arch-8.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aaefeb2b23276fe286fe554e7e69fea80daff4185ecdf9fc891ba1b2c1e49ad4", size = 964843, upload-time = "2025-10-21T09:13:48.538Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/40/7b7ac152c35c32da2a00ba3523ea84c358478b12ee7b3b2b6892e5b9d81b/arch-8.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8c1f1d8abefab2f69f7fdbef08cc18c8377667d3b8d197a1f301d97f0e686cd2", size = 982864, upload-time = "2025-10-21T09:13:50.494Z" },
+    { url = "https://files.pythonhosted.org/packages/80/40/d99c7d3e0a471d5e0f3e6b3ff1145db789e5a1c4e8fed25e8c22629e87fc/arch-8.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a985abc5367d225a6b346782dee9e7d84381c2af5ab795a6234aa1491c96f0bb", size = 985288, upload-time = "2025-10-21T09:13:52.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e7/2d15374129c03b6f97321f837190cb19863204dbcff289e23cc37f035c96/arch-8.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:bd73bd2d811bcf0551443b6e0a10bc25af002e9eb146aff164897c70aac35e85", size = 929688, upload-time = "2025-10-21T08:42:06.529Z" },
+    { url = "https://files.pythonhosted.org/packages/96/37/8d9ec002ec3e750f3ea2af42b67a1e3cf3a82523b556fd8d10d1f34a085a/arch-8.0.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:8015f7bdcc14800dc2dc2acb01dffebddebf587df4aa27f62671e809ccfdefb1", size = 940799, upload-time = "2025-10-21T08:49:28.848Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c8/533ad2ef4277d2f6c95e8038088de2d80c6a41137c7d23e00b08425e2c39/arch-8.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a5a2ee20c5a0d88eda12894d8fbb8320b7bfe3436c2e40fa16da918db54eb5b4", size = 931745, upload-time = "2025-10-21T08:50:02.936Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8e/27bf8ef574c507fd984283acd8b33ff066c2ee4beea4b8af9eada23a20f4/arch-8.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82113ee290afac972f73ad6f61b4b4ebd57bf9a288c2df163f9b2bc1874f89f3", size = 967633, upload-time = "2025-10-21T09:25:15.477Z" },
+    { url = "https://files.pythonhosted.org/packages/22/11/8a3b956a532b26fe4f325d9829b09eba725eb25a3e89d568673e2015beca/arch-8.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:563bea8e594f712a38ec2186f6dcd0d55a73f1c203bd228958cad495d9d471f1", size = 983273, upload-time = "2025-10-21T09:25:17.695Z" },
+    { url = "https://files.pythonhosted.org/packages/95/99/40ca7262d2cc5d74a7b8be10e8a254e0063969edb50959c489bad8d2adb4/arch-8.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:119766cdb3ac9ebdad4077dcf8238fb2a4554ba3c6503bd4431161f43923357e", size = 985658, upload-time = "2025-10-21T09:25:19.375Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/d1/14d3dab7283ea68a4e2d17be62d854af6df7e3d6f1b998a87d5be3ed8aed/arch-8.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:4849380bb831a1dc09891cd424f6623f163bde2403c66e376f9d0b5f8c1791c5", size = 934414, upload-time = "2025-10-21T08:44:28.636Z" },
+]
+
+[[package]]
 name = "arrow"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -884,6 +911,18 @@ wheels = [
 ]
 
 [[package]]
+name = "patsy"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/44/ed13eccdd0519eff265f44b670d46fbb0ec813e2274932dc1c0e48520f7d/patsy-1.0.2.tar.gz", hash = "sha256:cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0", size = 399942, upload-time = "2025-10-20T16:17:37.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/70/ba4b949bdc0490ab78d545459acd7702b211dfccf7eb89bbc1060f52818d/patsy-1.0.2-py2.py3-none-any.whl", hash = "sha256:37bfddbc58fcf0362febb5f54f10743f8b21dd2aa73dec7e7ef59d1b02ae668a", size = 233301, upload-time = "2025-10-20T16:17:36.563Z" },
+]
+
+[[package]]
 name = "peewee"
 version = "4.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1244,6 +1283,7 @@ name = "rubber-duck-debugger"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "arch" },
     { name = "finnhub-python" },
     { name = "kedro" },
     { name = "kedro-datasets", extra = ["pandas-parquetdataset"] },
@@ -1277,6 +1317,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "arch", specifier = ">=8.0.0" },
     { name = "finnhub-python", specifier = ">=2.4" },
     { name = "kedro", specifier = "~=1.2" },
     { name = "kedro-datasets", extras = ["pandas-parquetdataset"], specifier = ">=9.2" },
@@ -1334,6 +1375,57 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1367,6 +1459,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "statsmodels"
+version = "0.14.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/81/e8d74b34f85285f7335d30c5e3c2d7c0346997af9f3debf9a0a9a63de184/statsmodels-0.14.6.tar.gz", hash = "sha256:4d17873d3e607d398b85126cd4ed7aad89e4e9d89fc744cdab1af3189a996c2a", size = 20689085, upload-time = "2025-12-05T23:08:39.522Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/59/a5aad5b0cc266f5be013db8cde563ac5d2a025e7efc0c328d83b50c72992/statsmodels-0.14.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47ee7af083623d2091954fa71c7549b8443168f41b7c5dce66510274c50fd73e", size = 10072009, upload-time = "2025-12-05T23:11:14.021Z" },
+    { url = "https://files.pythonhosted.org/packages/53/dd/d8cfa7922fc6dc3c56fa6c59b348ea7de829a94cd73208c6f8202dd33f17/statsmodels-0.14.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa60d82e29fcd0a736e86feb63a11d2380322d77a9369a54be8b0965a3985f71", size = 9980018, upload-time = "2025-12-05T23:11:30.907Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/77/0ec96803eba444efd75dba32f2ef88765ae3e8f567d276805391ec2c98c6/statsmodels-0.14.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89ee7d595f5939cc20bf946faedcb5137d975f03ae080f300ebb4398f16a5bd4", size = 10060269, upload-time = "2025-12-05T23:11:46.338Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b9/fd41f1f6af13a1a1212a06bb377b17762feaa6d656947bf666f76300fc05/statsmodels-0.14.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:730f3297b26749b216a06e4327fe0be59b8d05f7d594fb6caff4287b69654589", size = 10324155, upload-time = "2025-12-05T23:12:01.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0f/a6900e220abd2c69cd0a07e3ad26c71984be6061415a60e0f17b152ecf08/statsmodels-0.14.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f1c08befa85e93acc992b72a390ddb7bd876190f1360e61d10cf43833463bc9c", size = 10349765, upload-time = "2025-12-05T23:12:18.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/08/b79f0c614f38e566eebbdcff90c0bcacf3c6ba7a5bbb12183c09c29ca400/statsmodels-0.14.6-cp313-cp313-win_amd64.whl", hash = "sha256:8021271a79f35b842c02a1794465a651a9d06ec2080f76ebc3b7adce77d08233", size = 9540043, upload-time = "2025-12-05T23:12:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/71/de/09540e870318e0c7b58316561d417be45eff731263b4234fdd2eee3511a8/statsmodels-0.14.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:00781869991f8f02ad3610da6627fd26ebe262210287beb59761982a8fa88cae", size = 10069403, upload-time = "2025-12-05T23:12:48.424Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f0/63c1bfda75dc53cee858006e1f46bd6d6f883853bea1b97949d0087766ca/statsmodels-0.14.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:73f305fbf31607b35ce919fae636ab8b80d175328ed38fdc6f354e813b86ee37", size = 9989253, upload-time = "2025-12-05T23:13:05.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/98/b0dfb4f542b2033a3341aa5f1bdd97024230a4ad3670c5b0839d54e3dcab/statsmodels-0.14.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e443e7077a6e2d3faeea72f5a92c9f12c63722686eb80bb40a0f04e4a7e267ad", size = 10090802, upload-time = "2025-12-05T23:13:20.653Z" },
+    { url = "https://files.pythonhosted.org/packages/34/0e/2408735aca9e764643196212f9069912100151414dd617d39ffc72d77eee/statsmodels-0.14.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3414e40c073d725007a6603a18247ab7af3467e1af4a5e5a24e4c27bc26673b4", size = 10337587, upload-time = "2025-12-05T23:13:37.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/36/4d44f7035ab3c0b2b6a4c4ebb98dedf36246ccbc1b3e2f51ebcd7ac83abb/statsmodels-0.14.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a518d3f9889ef920116f9fa56d0338069e110f823926356946dae83bc9e33e19", size = 10363350, upload-time = "2025-12-05T23:13:53.08Z" },
+    { url = "https://files.pythonhosted.org/packages/26/33/f1652d0c59fa51de18492ee2345b65372550501ad061daa38f950be390b6/statsmodels-0.14.6-cp314-cp314-win_amd64.whl", hash = "sha256:151b73e29f01fe619dbce7f66d61a356e9d1fe5e906529b78807df9189c37721", size = 9588010, upload-time = "2025-12-05T23:14:07.28Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a `strategies` Kedro pipeline that derives per-ticker trading signals from ingested OHLCV data and writes `data/strategies/stock_analyses.json` for downstream agent consumption.

- **Momentum** — 1m/3m/6m/12m price returns; bullish when majority of windows are positive
- **Trend** — MA50/MA200 golden/death cross; falls back to price-vs-MA50 when history is short
- **Mean reversion** — RSI(14) + Bollinger Bands; fixes RSI div-by-zero on pure-gain series
- **Volatility** — GARCH(1,1) on log returns; compares current conditional vol against the long-run unconditional vol. Bearish when elevated (ratio > 1.5), bullish when compressed (ratio < 0.75) — a regime descriptor, not a directional bet

All thresholds and windows are parameterised in `params_strategies.yml`. Fundamental and sentiment strategies are deferred until ingested data improves (issue #34).

Validated against 516 real tickers — 487 received a volatility signal (29 dropped for insufficient history). Sample: AAPL 25.9% current vs 24.5% long-run, NVDA 38.6% vs 50.5% (vol compressed post-run), KO 15.9% (lowest in the universe as expected).

## Changed files

| Path | What |
|---|---|
| `src/rdd/pipelines/strategies/` | `models.py`, `nodes.py`, `pipeline.py` |
| `conf/base/catalog/catalog_strategies.yml` | Intermediate `MemoryDataset`s + JSON output |
| `conf/base/parameters/params_strategies.yml` | Configurable strategy parameters |
| `tests/pipelines/strategies/` | 35 tests (29 unit + 6 pipeline integration) |
| `src/rdd/pipeline_registry.py` | Register `strategies` pipeline |
| `tests/conftest.py` | Add `make_price_ohlcv` helper |
| `pyproject.toml` | Add `arch` dependency; ruff ignores for strategies nodes |

## Test plan

- [x] `uv run pytest tests/pipelines/strategies/ -v` — 35 pass
- [x] All CI checks green (ruff, pytest, check-uv-lock, pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)