### PR TITLE
feat(data): company_financials pipeline — quarterly & annual statements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,14 @@ jobs:
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
+  test-pipelines-company-financials:
+    name: "Tests / Pipelines / company_financials"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-uv
+      - run: uv run --locked pytest tests/pipelines/company_financials
+
   test-pipelines-company-info:
     name: "Tests / Pipelines / company_info"
     runs-on: ubuntu-latest

--- a/conf/base/catalog/catalog_company_financials.yml
+++ b/conf/base/catalog/catalog_company_financials.yml
@@ -1,0 +1,47 @@
+raw_company_financials_quarterly_existing:
+  type: rdd.datasets.nullable_partitioned.NullablePartitionedDataset
+  path: ${globals:data_dir}raw/company_financials/quarterly
+  dataset:
+    type: pandas.ParquetDataset
+  filename_suffix: ".parquet"
+  metadata:
+    kedro-viz:
+      layer: raw
+
+raw_company_financials_quarterly:
+  type: kedro_datasets.partitions.PartitionedDataset
+  path: ${globals:data_dir}raw/company_financials/quarterly
+  dataset:
+    type: pandas.ParquetDataset
+  filename_suffix: ".parquet"
+  metadata:
+    kedro-viz:
+      layer: raw
+    pandera:
+      schema:
+        type: python.model
+        object_path: rdd.schemas.company_financials.CompanyFinancialsSchema
+
+raw_company_financials_annual_existing:
+  type: rdd.datasets.nullable_partitioned.NullablePartitionedDataset
+  path: ${globals:data_dir}raw/company_financials/annual
+  dataset:
+    type: pandas.ParquetDataset
+  filename_suffix: ".parquet"
+  metadata:
+    kedro-viz:
+      layer: raw
+
+raw_company_financials_annual:
+  type: kedro_datasets.partitions.PartitionedDataset
+  path: ${globals:data_dir}raw/company_financials/annual
+  dataset:
+    type: pandas.ParquetDataset
+  filename_suffix: ".parquet"
+  metadata:
+    kedro-viz:
+      layer: raw
+    pandera:
+      schema:
+        type: python.model
+        object_path: rdd.schemas.company_financials.CompanyFinancialsSchema

--- a/conf/base/parameters/params_company_financials.yml
+++ b/conf/base/parameters/params_company_financials.yml
@@ -1,0 +1,2 @@
+company_financials:
+  refresh_days: 7  # re-fetch a ticker's snapshot if it is older than this many days

--- a/scripts/run_daily_ingest.sh
+++ b/scripts/run_daily_ingest.sh
@@ -122,6 +122,7 @@ main() {
   run_pipeline data_ingestion
   run_pipeline company_info
   run_pipeline company_news
+  run_pipeline company_financials
   backfill_news
   run_pipeline strategies
 

--- a/src/rdd/pipeline_registry.py
+++ b/src/rdd/pipeline_registry.py
@@ -2,6 +2,9 @@
 
 from kedro.pipeline import Pipeline
 
+from rdd.pipelines.company_financials.pipeline import (
+    create_pipeline as company_financials,
+)
 from rdd.pipelines.company_info.pipeline import create_pipeline as company_info
 from rdd.pipelines.company_news.pipeline import create_pipeline as company_news
 from rdd.pipelines.data_ingestion.pipeline import create_pipeline as data_ingestion
@@ -13,11 +16,13 @@ def register_pipelines() -> dict[str, Pipeline]:
     di = data_ingestion()
     ci = company_info()
     cn = company_news()
+    cf = company_financials()
     st = strategies()
     return {
-        "__default__": di + ci + cn + st,
+        "__default__": di + ci + cn + cf + st,
         "data_ingestion": di,
         "company_info": ci,
         "company_news": cn,
+        "company_financials": cf,
         "strategies": st,
     }

--- a/src/rdd/pipelines/company_financials/__init__.py
+++ b/src/rdd/pipelines/company_financials/__init__.py
@@ -1,0 +1,1 @@
+"""Company financials ingestion pipeline."""

--- a/src/rdd/pipelines/company_financials/nodes.py
+++ b/src/rdd/pipelines/company_financials/nodes.py
@@ -1,0 +1,230 @@
+"""Nodes for the company financials ingestion pipeline (yfinance)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import pandas as pd
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+# Maps yfinance income-statement row names → schema column names
+_INCOME_FIELDS: dict[str, str] = {
+    "Total Revenue": "total_revenue",
+    "Gross Profit": "gross_profit",
+    "Operating Income": "operating_income",
+    "Net Income": "net_income",
+    "EBITDA": "ebitda",
+    "EBIT": "ebit",
+    "Diluted EPS": "diluted_eps",
+    "Basic EPS": "basic_eps",
+    "Cost Of Revenue": "cost_of_revenue",
+    "Research And Development": "research_and_development",
+    "Selling General And Administration": "selling_general_and_administration",
+    "Pretax Income": "pretax_income",
+    "Tax Provision": "tax_provision",
+}
+
+_BALANCE_FIELDS: dict[str, str] = {
+    "Total Assets": "total_assets",
+    "Total Liabilities Net Minority Interest": "total_liabilities",
+    "Common Stock Equity": "equity",
+    "Total Debt": "total_debt",
+    "Cash And Cash Equivalents": "cash_and_equivalents",
+    "Net Debt": "net_debt",
+    "Working Capital": "working_capital",
+    "Net PPE": "net_ppe",
+    "Accounts Receivable": "accounts_receivable",
+    "Inventory": "inventory",
+    "Accounts Payable": "accounts_payable",
+    "Long Term Debt": "long_term_debt",
+}
+
+_CASHFLOW_FIELDS: dict[str, str] = {
+    "Free Cash Flow": "free_cash_flow",
+    "Operating Cash Flow": "operating_cash_flow",
+    "Capital Expenditure": "capital_expenditure",
+    "Cash Dividends Paid": "cash_dividends_paid",
+    "Stock Based Compensation": "stock_based_compensation",
+    "Depreciation And Amortization": "depreciation_and_amortization",
+    "Net Long Term Debt Issuance": "net_long_term_debt_issuance",
+    "Repurchase Of Capital Stock": "repurchase_of_capital_stock",
+}
+
+# All schema columns (excluding ticker, period_end, fetched_at)
+_ALL_METRIC_COLS: list[str] = (
+    list(_INCOME_FIELDS.values())
+    + list(_BALANCE_FIELDS.values())
+    + list(_CASHFLOW_FIELDS.values())
+)
+
+
+def _extract_statement(
+    raw: pd.DataFrame,
+    field_map: dict[str, str],
+) -> pd.DataFrame:
+    """Transpose a yfinance statement DataFrame and rename columns.
+
+    yfinance returns metrics as rows, periods as columns.
+    Returns a DataFrame with periods as rows, selected metrics as columns.
+    """
+    if raw is None or raw.empty:
+        return pd.DataFrame()
+    # Transpose: rows → periods, cols → metrics
+    df = raw.T.copy()
+    df.index.name = "period_end"
+    df = df.reset_index()
+    df["period_end"] = pd.to_datetime(df["period_end"]).dt.tz_localize(None)
+    renamed: dict[str, str] = {}
+    for src, dst in field_map.items():
+        if src in df.columns:
+            renamed[src] = dst
+    df = df.rename(columns=renamed)
+    keep = ["period_end"] + [c for c in field_map.values() if c in df.columns]
+    return df[keep]
+
+
+def _merge_statements(*dfs: pd.DataFrame) -> pd.DataFrame:
+    """Outer-merge multiple statement DataFrames on period_end."""
+    result = dfs[0]
+    for other in dfs[1:]:
+        if other.empty:
+            continue
+        result = result.merge(other, on="period_end", how="outer")
+    return result
+
+
+def _fetch_financials(
+    ticker: str,
+    quarterly: bool,
+) -> pd.DataFrame | None:
+    """Fetch and merge all three financial statements for one ticker.
+
+    Returns None if yfinance raises an exception.
+    """
+    try:
+        t = yf.Ticker(ticker)
+        if quarterly:
+            income = _extract_statement(t.quarterly_financials, _INCOME_FIELDS)
+            balance = _extract_statement(t.quarterly_balance_sheet, _BALANCE_FIELDS)
+            cashflow = _extract_statement(t.quarterly_cashflow, _CASHFLOW_FIELDS)
+        else:
+            income = _extract_statement(t.financials, _INCOME_FIELDS)
+            balance = _extract_statement(t.balance_sheet, _BALANCE_FIELDS)
+            cashflow = _extract_statement(t.cashflow, _CASHFLOW_FIELDS)
+    except Exception:
+        logger.warning(
+            "Failed to fetch financials for %s — skipping.", ticker, exc_info=True
+        )
+        return None
+
+    non_empty = [df for df in (income, balance, cashflow) if not df.empty]
+    if not non_empty:
+        return None
+
+    merged = _merge_statements(*non_empty)
+    merged["ticker"] = ticker
+    merged["fetched_at"] = pd.Timestamp.now("UTC").tz_convert(None).floor("s")
+
+    # Ensure all metric columns exist (fill missing with NaN)
+    for col in _ALL_METRIC_COLS:
+        if col not in merged.columns:
+            merged[col] = float("nan")
+
+    cols = ["ticker", "period_end", *_ALL_METRIC_COLS, "fetched_at"]
+    return merged[cols].sort_values("period_end").reset_index(drop=True)
+
+
+def _is_fresh(
+    df: pd.DataFrame,
+    cutoff: pd.Timestamp,
+) -> bool:
+    if df.empty or "fetched_at" not in df.columns:
+        return False
+    return pd.Timestamp(df["fetched_at"].iloc[0]) >= cutoff
+
+
+def _partition_fresh_stale(
+    ticker_universe: list[str],
+    existing: dict[str, Callable[[], pd.DataFrame]],
+    cutoff: pd.Timestamp,
+    label: str,
+) -> tuple[dict[str, pd.DataFrame], list[str]]:
+    """Split tickers into a dict of fresh DataFrames and a list of stale ticker names."""
+    fresh: dict[str, pd.DataFrame] = {}
+    stale: list[str] = []
+    for ticker in ticker_universe:
+        key = ticker.lower()
+        if key not in existing:
+            stale.append(ticker)
+            continue
+        try:
+            df = existing[key]()
+            if _is_fresh(df, cutoff):
+                fresh[key] = df
+            else:
+                stale.append(ticker)
+        except Exception:
+            logger.warning("Could not load existing %s data for %s.", label, ticker)
+            stale.append(ticker)
+    return fresh, stale
+
+
+def ingest_company_financials(
+    ticker_universe: list[str],
+    existing_quarterly: dict[str, Callable[[], pd.DataFrame]],
+    existing_annual: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> tuple[dict[str, pd.DataFrame], dict[str, pd.DataFrame]]:
+    """Fetch quarterly and annual financial statements from yfinance.
+
+    Skips tickers whose stored data is fresher than ``params.refresh_days``.
+    Failed fetches are logged and skipped.
+
+    Args:
+        ticker_universe: Sorted list of ticker symbols to process.
+        existing_quarterly: Lazy loaders from quarterly PartitionedDataset.
+        existing_annual: Lazy loaders from annual PartitionedDataset.
+        params: ``company_financials`` parameter block.
+
+    Returns:
+        Tuple of (quarterly_dict, annual_dict) mapping ticker (lowercase) →
+        DataFrame for the PartitionedDataset to persist.
+    """
+    refresh_days = int(params["refresh_days"])
+    cutoff = pd.Timestamp.now("UTC").tz_convert(None) - pd.Timedelta(days=refresh_days)
+
+    quarterly_out, stale_q = _partition_fresh_stale(
+        ticker_universe, existing_quarterly, cutoff, "quarterly"
+    )
+    annual_out, stale_a = _partition_fresh_stale(
+        ticker_universe, existing_annual, cutoff, "annual"
+    )
+
+    logger.info(
+        "Quarterly: %d up to date, %d to fetch. Annual: %d up to date, %d to fetch.",
+        len(quarterly_out),
+        len(stale_q),
+        len(annual_out),
+        len(stale_a),
+    )
+
+    for ticker in stale_q:
+        df = _fetch_financials(ticker, quarterly=True)
+        if df is not None:
+            quarterly_out[ticker.lower()] = df
+
+    for ticker in stale_a:
+        df = _fetch_financials(ticker, quarterly=False)
+        if df is not None:
+            annual_out[ticker.lower()] = df
+
+    logger.info(
+        "Company financials complete. %d quarterly, %d annual tickers written.",
+        len(quarterly_out),
+        len(annual_out),
+    )
+    return quarterly_out, annual_out

--- a/src/rdd/pipelines/company_financials/pipeline.py
+++ b/src/rdd/pipelines/company_financials/pipeline.py
@@ -1,0 +1,27 @@
+"""Company financials ingestion pipeline — quarterly and annual statements from yfinance."""
+
+from kedro.pipeline import Pipeline, node
+
+from rdd.pipelines.company_financials.nodes import ingest_company_financials
+
+
+def create_pipeline(**_kwargs) -> Pipeline:
+    """Create the company financials ingestion pipeline."""
+    return Pipeline(
+        nodes=[
+            node(
+                func=ingest_company_financials,
+                inputs=[
+                    "ticker_universe",
+                    "raw_company_financials_quarterly_existing",
+                    "raw_company_financials_annual_existing",
+                    "params:company_financials",
+                ],
+                outputs=[
+                    "raw_company_financials_quarterly",
+                    "raw_company_financials_annual",
+                ],
+                name="ingest_company_financials",
+            ),
+        ]
+    )

--- a/src/rdd/schemas/company_financials.py
+++ b/src/rdd/schemas/company_financials.py
@@ -1,0 +1,70 @@
+"""Pandera schema for company financial statements (income, balance sheet, cash flow)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pandera.pandas as pa
+from pandera.pandas import DataFrameModel
+from pandera.typing import Series
+
+
+class CompanyFinancialsSchema(DataFrameModel):
+    """Schema for company financials fetched from yfinance.
+
+    One row = one reporting period for one ticker.
+    Applies to both quarterly and annual datasets — same columns, different cadence.
+    All monetary values are in the reporting currency (typically USD).
+    """
+
+    ticker: Series[str] = pa.Field(nullable=False)
+    period_end: Series[pd.Timestamp] = pa.Field(
+        nullable=False,
+        description="Period end date as reported (tz-naive).",
+    )
+
+    # --- Income Statement ---
+    total_revenue: Series[float] = pa.Field(nullable=True, ge=0)
+    gross_profit: Series[float] = pa.Field(nullable=True)
+    operating_income: Series[float] = pa.Field(nullable=True)
+    net_income: Series[float] = pa.Field(nullable=True)
+    ebitda: Series[float] = pa.Field(nullable=True)
+    ebit: Series[float] = pa.Field(nullable=True)
+    diluted_eps: Series[float] = pa.Field(nullable=True)
+    basic_eps: Series[float] = pa.Field(nullable=True)
+    cost_of_revenue: Series[float] = pa.Field(nullable=True)
+    research_and_development: Series[float] = pa.Field(nullable=True)
+    selling_general_and_administration: Series[float] = pa.Field(nullable=True)
+    pretax_income: Series[float] = pa.Field(nullable=True)
+    tax_provision: Series[float] = pa.Field(nullable=True)
+
+    # --- Balance Sheet ---
+    total_assets: Series[float] = pa.Field(nullable=True)
+    total_liabilities: Series[float] = pa.Field(nullable=True)
+    equity: Series[float] = pa.Field(nullable=True)
+    total_debt: Series[float] = pa.Field(nullable=True)
+    cash_and_equivalents: Series[float] = pa.Field(nullable=True)
+    net_debt: Series[float] = pa.Field(nullable=True)
+    working_capital: Series[float] = pa.Field(nullable=True)
+    net_ppe: Series[float] = pa.Field(nullable=True)
+    accounts_receivable: Series[float] = pa.Field(nullable=True)
+    inventory: Series[float] = pa.Field(nullable=True)
+    accounts_payable: Series[float] = pa.Field(nullable=True)
+    long_term_debt: Series[float] = pa.Field(nullable=True)
+
+    # --- Cash Flow ---
+    free_cash_flow: Series[float] = pa.Field(nullable=True)
+    operating_cash_flow: Series[float] = pa.Field(nullable=True)
+    capital_expenditure: Series[float] = pa.Field(nullable=True)
+    cash_dividends_paid: Series[float] = pa.Field(nullable=True)
+    stock_based_compensation: Series[float] = pa.Field(nullable=True)
+    depreciation_and_amortization: Series[float] = pa.Field(nullable=True)
+    net_long_term_debt_issuance: Series[float] = pa.Field(nullable=True)
+    repurchase_of_capital_stock: Series[float] = pa.Field(nullable=True)
+
+    fetched_at: Series[pd.Timestamp] = pa.Field(nullable=False)
+
+    class Config:
+        """Pandera config."""
+
+        strict = True
+        coerce = True

--- a/tests/pipelines/company_financials/test_nodes.py
+++ b/tests/pipelines/company_financials/test_nodes.py
@@ -1,0 +1,242 @@
+"""Unit tests for company_financials nodes.
+
+Network is disabled globally via --disable-socket.  All yfinance calls are
+patched with pytest-mock.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import MagicMock, PropertyMock
+
+import pandas as pd
+import pytest
+
+from rdd.pipelines.company_financials.nodes import (
+    _ALL_METRIC_COLS,
+    _BALANCE_FIELDS,
+    _INCOME_FIELDS,
+    _extract_statement,
+    _fetch_financials,
+    _merge_statements,
+    ingest_company_financials,
+)
+
+_DATE = pd.Timestamp("2024-09-30")
+_DATE2 = pd.Timestamp("2024-06-30")
+
+_INCOME_RAW = pd.DataFrame(
+    {
+        _DATE: {"Total Revenue": 100_000, "Net Income": 20_000, "EBITDA": 30_000},
+        _DATE2: {"Total Revenue": 90_000, "Net Income": 18_000, "EBITDA": 27_000},
+    }
+)
+
+_BALANCE_RAW = pd.DataFrame(
+    {
+        _DATE: {"Total Assets": 300_000, "Total Debt": 50_000},
+        _DATE2: {"Total Assets": 280_000, "Total Debt": 55_000},
+    }
+)
+
+_CASHFLOW_RAW = pd.DataFrame(
+    {
+        _DATE: {"Free Cash Flow": 25_000, "Operating Cash Flow": 35_000},
+        _DATE2: {"Free Cash Flow": 22_000, "Operating Cash Flow": 31_000},
+    }
+)
+
+
+@pytest.fixture
+def base_params() -> dict:
+    return {"refresh_days": 7}
+
+
+def _make_mock_ticker(
+    quarterly: bool | None = None,
+    income: pd.DataFrame = _INCOME_RAW,
+    balance: pd.DataFrame = _BALANCE_RAW,
+    cashflow: pd.DataFrame = _CASHFLOW_RAW,
+) -> MagicMock:
+    """Build a mock yf.Ticker. quarterly=None sets both quarterly and annual props."""
+    mock = MagicMock()
+    if quarterly is None or quarterly:
+        type(mock).quarterly_financials = PropertyMock(return_value=income)
+        type(mock).quarterly_balance_sheet = PropertyMock(return_value=balance)
+        type(mock).quarterly_cashflow = PropertyMock(return_value=cashflow)
+    if quarterly is None or not quarterly:
+        type(mock).financials = PropertyMock(return_value=income)
+        type(mock).balance_sheet = PropertyMock(return_value=balance)
+        type(mock).cashflow = PropertyMock(return_value=cashflow)
+    return mock
+
+
+class TestExtractStatement:
+    def test_transposes_and_renames(self) -> None:
+        df = _extract_statement(_INCOME_RAW, _INCOME_FIELDS)
+
+        assert "period_end" in df.columns
+        assert "total_revenue" in df.columns
+        assert "net_income" in df.columns
+        assert len(df) == 2
+
+    def test_empty_input_returns_empty(self) -> None:
+        df = _extract_statement(pd.DataFrame(), _INCOME_FIELDS)
+
+        assert df.empty
+
+    def test_none_input_returns_empty(self) -> None:
+        df = _extract_statement(None, _INCOME_FIELDS)
+
+        assert df.empty
+
+    def test_period_end_is_tz_naive(self) -> None:
+        df = _extract_statement(_INCOME_RAW, _INCOME_FIELDS)
+
+        assert df["period_end"].dt.tz is None
+
+
+class TestMergeStatements:
+    def test_merges_on_period_end(self) -> None:
+        income = _extract_statement(_INCOME_RAW, _INCOME_FIELDS)
+        balance = _extract_statement(_BALANCE_RAW, _BALANCE_FIELDS)
+        merged = _merge_statements(income, balance)
+
+        assert "total_revenue" in merged.columns
+        assert "total_assets" in merged.columns
+        assert len(merged) == 2
+
+
+class TestFetchFinancials:
+    def test_quarterly_fetch_returns_dataframe(self, mocker) -> None:
+        mock = _make_mock_ticker(quarterly=True)
+        mocker.patch(
+            "rdd.pipelines.company_financials.nodes.yf.Ticker",
+            return_value=mock,
+        )
+
+        df = _fetch_financials("AAPL", quarterly=True)
+
+        assert df is not None
+        assert "ticker" in df.columns
+        assert df["ticker"].iloc[0] == "AAPL"
+        assert "period_end" in df.columns
+        assert "total_revenue" in df.columns
+
+    def test_annual_fetch_returns_dataframe(self, mocker) -> None:
+        mock = _make_mock_ticker(quarterly=False)
+        mocker.patch(
+            "rdd.pipelines.company_financials.nodes.yf.Ticker",
+            return_value=mock,
+        )
+
+        df = _fetch_financials("AAPL", quarterly=False)
+
+        assert df is not None
+        assert len(df) == 2
+
+    def test_exception_returns_none(self, mocker) -> None:
+        mocker.patch(
+            "rdd.pipelines.company_financials.nodes.yf.Ticker",
+            side_effect=RuntimeError("API error"),
+        )
+
+        df = _fetch_financials("AAPL", quarterly=True)
+
+        assert df is None
+
+    def test_all_metric_cols_present(self, mocker) -> None:
+        mock = _make_mock_ticker(quarterly=True)
+        mocker.patch(
+            "rdd.pipelines.company_financials.nodes.yf.Ticker",
+            return_value=mock,
+        )
+
+        df = _fetch_financials("AAPL", quarterly=True)
+
+        assert df is not None
+        for col in _ALL_METRIC_COLS:
+            assert col in df.columns, f"Missing column: {col}"
+
+    def test_fetched_at_is_set(self, mocker) -> None:
+        mock = _make_mock_ticker(quarterly=True)
+        mocker.patch(
+            "rdd.pipelines.company_financials.nodes.yf.Ticker",
+            return_value=mock,
+        )
+
+        df = _fetch_financials("AAPL", quarterly=True)
+
+        assert df is not None
+        assert "fetched_at" in df.columns
+        assert isinstance(df["fetched_at"].iloc[0], pd.Timestamp)
+
+
+class TestIngestCompanyFinancials:
+    def test_first_run_fetches_all_tickers(self, mocker, base_params) -> None:
+        mock = _make_mock_ticker(quarterly=None)
+        mocker.patch(
+            "rdd.pipelines.company_financials.nodes.yf.Ticker",
+            return_value=mock,
+        )
+
+        quarterly, annual = ingest_company_financials(
+            ["AAPL", "MSFT"], {}, {}, base_params
+        )
+
+        assert "aapl" in quarterly
+        assert "msft" in quarterly
+        assert "aapl" in annual
+        assert "msft" in annual
+
+    def test_fresh_data_not_refetched(self, mocker, base_params) -> None:
+        fresh = pd.DataFrame(
+            {
+                "ticker": ["AAPL"],
+                "period_end": [pd.Timestamp("2024-09-30")],
+                "fetched_at": [pd.Timestamp.now("UTC").tz_convert(None)],
+            }
+        )
+
+        existing_q: dict[str, Callable[[], pd.DataFrame]] = {"aapl": lambda: fresh}
+        existing_a: dict[str, Callable[[], pd.DataFrame]] = {"aapl": lambda: fresh}
+        yf_spy = mocker.patch("rdd.pipelines.company_financials.nodes.yf.Ticker")
+
+        ingest_company_financials(["AAPL"], existing_q, existing_a, base_params)
+
+        yf_spy.assert_not_called()
+
+    def test_stale_data_is_refetched(self, mocker, base_params) -> None:
+        stale = pd.DataFrame(
+            {
+                "ticker": ["AAPL"],
+                "period_end": [pd.Timestamp("2024-09-30")],
+                "fetched_at": [pd.Timestamp("2000-01-01")],
+            }
+        )
+        existing_q: dict[str, Callable[[], pd.DataFrame]] = {"aapl": lambda: stale}
+        existing_a: dict[str, Callable[[], pd.DataFrame]] = {"aapl": lambda: stale}
+
+        mock = _make_mock_ticker(quarterly=None)
+        mocker.patch(
+            "rdd.pipelines.company_financials.nodes.yf.Ticker",
+            return_value=mock,
+        )
+
+        quarterly, _ = ingest_company_financials(
+            ["AAPL"], existing_q, existing_a, base_params
+        )
+
+        assert "aapl" in quarterly
+        assert quarterly["aapl"]["ticker"].iloc[0] == "AAPL"
+
+    def test_failed_fetch_is_skipped(self, mocker, base_params) -> None:
+        mocker.patch(
+            "rdd.pipelines.company_financials.nodes.yf.Ticker",
+            side_effect=RuntimeError("API error"),
+        )
+
+        quarterly, annual = ingest_company_financials(["AAPL"], {}, {}, base_params)
+
+        assert quarterly == {}
+        assert annual == {}


### PR DESCRIPTION
## Summary

- Ports the `company_financials` pipeline to `main` (code existed in a feature branch but was never merged)
- Ingests income statement, balance sheet, and cash flow via yfinance for every ticker in the S&P 500 / NASDAQ-100 universe
- Stores quarterly and annual data separately as partitioned parquet (one file per ticker)
- Refreshes stale snapshots only (configurable `refresh_days: 7`)
- Pandera schema validates all 33 financial fields
- Registered as `company_financials` in the Kedro pipeline registry
- Added to `run_daily_ingest.sh` between `company_news` and `strategies`
- CI job added: `Tests / Pipelines / company_financials`

## Test plan

- [ ] 14 unit tests pass (all yfinance calls mocked, network disabled)
- [ ] Fresh data is not re-fetched (staleness check)
- [ ] Stale / missing data triggers a fetch
- [ ] Failed fetches are skipped gracefully
- [ ] All 33 metric columns are present in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)