### PR TITLE
fix(schema): remove ge=0 constraint on total_revenue

### DIFF
--- a/src/rdd/schemas/company_financials.py
+++ b/src/rdd/schemas/company_financials.py
@@ -23,7 +23,7 @@ class CompanyFinancialsSchema(DataFrameModel):
     )
 
     # --- Income Statement ---
-    total_revenue: Series[float] = pa.Field(nullable=True, ge=0)
+    total_revenue: Series[float] = pa.Field(nullable=True)
     gross_profit: Series[float] = pa.Field(nullable=True)
     operating_income: Series[float] = pa.Field(nullable=True)
     net_income: Series[float] = pa.Field(nullable=True)


### PR DESCRIPTION
## Summary

- Removes `ge=0` from `total_revenue` in `CompanyFinancialsSchema`

## Why

Negative total revenue is rare but valid — observed in production when a company reported `-$1,871,000,000`, causing the daily `company_financials` pipeline to crash with a `SchemaErrors` validation failure. Revenue can go negative due to contract reversals, adjustments, or accounting treatments.

## Test plan

- [x] Existing schema and pipeline tests pass (`uv run pytest tests/schemas/ tests/pipelines/data_ingestion/company_financials/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)