### PR TITLE
feat(portfolio): three-stage Claude agent portfolio construction pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,14 @@ jobs:
       - uses: ./.github/actions/setup-python-uv
       - run: uv run --locked pytest tests/pipelines/feature_engineering/news_analysis
 
+  test-pipelines-portfolio-construction:
+    name: "Tests / Pipelines / portfolio_construction"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-uv
+      - run: uv run --locked pytest tests/pipelines/portfolio_construction
+
   test-schemas:
     name: "Tests / Schemas"
     runs-on: ubuntu-latest

--- a/conf/base/catalog/catalog_portfolio_construction.yml
+++ b/conf/base/catalog/catalog_portfolio_construction.yml
@@ -1,0 +1,17 @@
+portfolio_ticker_scores:
+  type: kedro_datasets.json.JSONDataset
+  filepath: "${globals:data_dir}portfolio/ticker_scores.json"
+
+portfolio_allocation:
+  type: kedro_datasets.json.JSONDataset
+  filepath: "${globals:data_dir}portfolio/allocation.json"
+
+# live_portfolio is maintained externally (updated after trades are executed).
+# Returns {} on first run so the pipeline treats it as no prior holdings.
+live_portfolio:
+  type: rdd.datasets.nullable_json.NullableJSONDataset
+  filepath: "${globals:data_dir}portfolio/live_portfolio.json"
+
+portfolio_trades:
+  type: kedro_datasets.json.JSONDataset
+  filepath: "${globals:data_dir}portfolio/trades.json"

--- a/conf/base/parameters/params_portfolio_construction.yml
+++ b/conf/base/parameters/params_portfolio_construction.yml
@@ -1,0 +1,14 @@
+portfolio_construction:
+  model_screening: "claude-haiku-4-5-20251001"
+  model_selection: "claude-sonnet-4-6"
+  model_rebalancing: "claude-haiku-4-5-20251001"
+  max_tokens_screening: 512
+  max_tokens_selection: 4096
+  max_tokens_rebalancing: 2048
+  top_n_candidates: 30
+  max_holdings: 10
+  max_industry_weight: 0.35
+  min_position_weight: 0.05
+  max_position_weight: 0.20
+  continuity_bonus: 0.08
+  refresh_hours: 720

--- a/src/rdd/datasets/nullable_json.py
+++ b/src/rdd/datasets/nullable_json.py
@@ -1,0 +1,38 @@
+"""NullableJSONDataset — returns {} when the target file does not exist."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from kedro.io import AbstractDataset
+
+
+class NullableJSONDataset(AbstractDataset):
+    """JSONDataset that returns an empty dict instead of raising when the file is missing.
+
+    Used for datasets that may not exist on the first pipeline run (e.g. the
+    live portfolio state before any trades have been executed).
+    """
+
+    def __init__(self, filepath: str) -> None:
+        """Initialise with a file path to the target JSON file."""
+        self._filepath = Path(filepath)
+
+    def _load(self) -> dict[str, Any]:
+        if not self._filepath.exists():
+            return {}
+        with open(self._filepath) as f:
+            return json.load(f)
+
+    def _save(self, data: dict[str, Any]) -> None:
+        self._filepath.parent.mkdir(parents=True, exist_ok=True)
+        with open(self._filepath, "w") as f:
+            json.dump(data, f, indent=2)
+
+    def _describe(self) -> dict[str, Any]:
+        return {"filepath": str(self._filepath)}
+
+    def _exists(self) -> bool:
+        return self._filepath.exists()

--- a/src/rdd/pipeline_registry.py
+++ b/src/rdd/pipeline_registry.py
@@ -29,6 +29,9 @@ from rdd.pipelines.feature_engineering.news_analysis.pipeline import (
 from rdd.pipelines.feature_engineering.strategies.pipeline import (
     create_pipeline as strategies,
 )
+from rdd.pipelines.portfolio_construction.pipeline import (
+    create_pipeline as portfolio_construction,
+)
 
 
 def register_pipelines() -> dict[str, Pipeline]:
@@ -42,8 +45,9 @@ def register_pipelines() -> dict[str, Pipeline]:
     eh = earnings_history()
     st = strategies()
     na = news_analysis()
+    pc = portfolio_construction()
     return {
-        "__default__": sp + ci + cn + cf + vr + ac + eh + st + na,
+        "__default__": sp + ci + cn + cf + vr + ac + eh + st + na + pc,
         "stock_prices": sp,
         "company_info": ci,
         "company_news": cn,
@@ -53,4 +57,5 @@ def register_pipelines() -> dict[str, Pipeline]:
         "earnings_history": eh,
         "strategies": st,
         "news_analysis": na,
+        "portfolio_construction": pc,
     }

--- a/src/rdd/pipelines/portfolio_construction/__init__.py
+++ b/src/rdd/pipelines/portfolio_construction/__init__.py
@@ -1,0 +1,1 @@
+"""Portfolio construction pipeline."""

--- a/src/rdd/pipelines/portfolio_construction/nodes.py
+++ b/src/rdd/pipelines/portfolio_construction/nodes.py
@@ -1,0 +1,536 @@
+"""Nodes for the portfolio_construction pipeline (Claude agent-driven).
+
+Three-stage decision flow:
+  1. score_tickers   — Haiku scores every ticker in the universe (~$0.80/month)
+  2. construct_portfolio — Sonnet selects 10 holdings with conviction weights (~$0.03/month)
+  3. rebalance_portfolio — Haiku decides which trades to execute (~$0.01/month)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+from collections.abc import Callable
+from typing import Any
+
+import anthropic
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+# ── API client ────────────────────────────────────────────────────────────────
+
+
+def _resolve_api_key() -> str:
+    key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if key:
+        return key
+    settings_path = os.path.expanduser("~/.claude/settings.json")
+    try:
+        with open(settings_path) as f:
+            helper = json.load(f).get("apiKeyHelper", "")
+    except Exception:
+        helper = ""
+    if not helper:
+        msg = "ANTHROPIC_API_KEY not set and no apiKeyHelper found in ~/.claude/settings.json."
+        raise OSError(msg)
+    result = subprocess.run([helper], capture_output=True, text=True, check=True)  # noqa: S603
+    return result.stdout.strip()
+
+
+def _make_client() -> anthropic.Anthropic:
+    api_key = _resolve_api_key()
+    base_url = os.environ.get("ANTHROPIC_BASE_URL")
+    kwargs: dict[str, str] = {"api_key": api_key}
+    if base_url:
+        kwargs["base_url"] = base_url
+    return anthropic.Anthropic(**kwargs)
+
+
+def _call_claude(
+    client: anthropic.Anthropic,
+    prompt: str,
+    model: str,
+    max_tokens: int,
+) -> str:
+    message = client.messages.create(
+        model=model,
+        max_tokens=max_tokens,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return message.content[0].text.strip()
+
+
+def _parse_json_response(text: str) -> dict[str, Any]:
+    """Parse a Claude response as JSON, stripping markdown fences if present."""
+    clean = re.sub(r"```(?:json)?\s*", "", text).strip().rstrip("`").strip()
+    return json.loads(clean)
+
+
+# ── Ticker brief ──────────────────────────────────────────────────────────────
+
+
+def _build_ticker_brief(  # noqa: PLR0912
+    ticker: str,
+    info: pd.DataFrame | None,
+    valuation: pd.DataFrame | None,
+    consensus: pd.DataFrame | None,
+    earnings: pd.DataFrame | None,
+    financials: pd.DataFrame | None,
+    strategy_signals: dict[str, Any] | None,
+    news: dict[str, Any] | None,
+) -> str:
+    """Compile all available data into a compact ~400-token text brief."""
+    parts: list[str] = [f"TICKER: {ticker}"]
+
+    if info is not None and not info.empty:
+        row = info.iloc[0]
+        mcap = row.get("market_cap")
+        mcap_str = f"${mcap / 1e9:.1f}B" if pd.notna(mcap) else "n/a"
+        parts.append(
+            f"Company: {row.get('name', 'n/a')} | Sector: {row.get('sector', 'n/a')}"
+            f" | Industry: {row.get('industry', 'n/a')} | Market cap: {mcap_str}"
+        )
+
+    if strategy_signals and "signals" in strategy_signals:
+        sig_lines = [
+            f"  {s['strategy']}: {s['direction']}" for s in strategy_signals["signals"]
+        ]
+        parts.append("Strategy signals:\n" + "\n".join(sig_lines))
+
+    if valuation is not None and not valuation.empty:
+        row = valuation.iloc[-1]
+        vlines = []
+        for col, label in [
+            ("pe_ratio", "P/E"),
+            ("ev_ebitda", "EV/EBITDA"),
+            ("pb_ratio", "P/B"),
+            ("gross_margin", "Gross margin"),
+            ("operating_margin", "Op margin"),
+            ("free_cash_flow_yield", "FCF yield"),
+        ]:
+            val = row.get(col)
+            if pd.notna(val):
+                vlines.append(f"  {label}: {val:.2f}")
+        if vlines:
+            parts.append("Valuation:\n" + "\n".join(vlines))
+
+    if financials is not None and not financials.empty:
+        latest = financials.sort_values("period_end").iloc[-1]
+        flines = []
+        for col, label in [
+            ("total_revenue", "Revenue"),
+            ("operating_income", "Op income"),
+            ("free_cash_flow", "FCF"),
+            ("net_debt", "Net debt"),
+        ]:
+            val = latest.get(col)
+            if pd.notna(val):
+                flines.append(f"  {label}: ${val / 1e9:.2f}B")
+        if flines:
+            parts.append(
+                f"Latest quarter ({latest['period_end'].date()}):\n" + "\n".join(flines)
+            )
+
+    if consensus is not None and not consensus.empty:
+        row = consensus.iloc[-1]
+        current = row.get("current_price")
+        target = row.get("target_mean_price")
+        if pd.notna(current) and pd.notna(target) and current > 0:
+            upside = f"{(target / current - 1) * 100:.1f}%"
+        else:
+            upside = "n/a"
+        parts.append(
+            f"Analyst consensus: {row.get('recommendation_key', 'n/a')}"
+            f" | Mean target: ${target:.0f} | Upside: {upside}"
+            f" | Analysts: {int(row.get('analyst_count', 0)) if pd.notna(row.get('analyst_count')) else 'n/a'}"
+        )
+
+    if earnings is not None and not earnings.empty:
+        recent = earnings.sort_values("earnings_date").tail(4)
+        surprises = [
+            f"{row['surprise_pct']:+.1f}%"
+            for _, row in recent.iterrows()
+            if pd.notna(row.get("surprise_pct"))
+        ]
+        if surprises:
+            parts.append(
+                f"EPS surprises (newest first): {', '.join(reversed(surprises))}"
+            )
+
+    if news and isinstance(news, dict):
+        bull = news.get("bull_report", "")
+        conviction_match = re.search(r"conviction\s+(\d)/5", bull, re.IGNORECASE)
+        conviction = conviction_match.group(1) if conviction_match else "n/a"
+        target_match = re.search(r"price target[^$]*\$(\d+)", bull, re.IGNORECASE)
+        price_target = f"${target_match.group(1)}" if target_match else "n/a"
+        parts.append(
+            f"News analysis: bull conviction {conviction}/5 | implied target {price_target}"
+        )
+
+    return "\n".join(parts)
+
+
+# ── Prompts ───────────────────────────────────────────────────────────────────
+
+_SCORE_PROMPT = """\
+You are a quantitative analyst screening stocks for a long-only equity portfolio.
+
+Review the data brief below for {ticker} and assign:
+1. A score from 1.0 to 10.0 (10 = strongest buy candidate)
+2. A verdict: STRONG_BUY, BUY, HOLD, or AVOID
+3. A one-sentence investment thesis (max 30 words)
+
+Respond with valid JSON only, no markdown fences:
+{{"score": <float>, "verdict": "<str>", "thesis": "<str>"}}
+
+Data brief:
+{brief}
+"""
+
+_SELECT_PROMPT = """\
+You are a portfolio manager constructing a 10-stock long-only equity portfolio.
+
+HARD CONSTRAINTS:
+- Exactly {max_holdings} holdings
+- Weights must sum to exactly 1.0
+- Each weight between {min_weight:.0%} and {max_weight:.0%}
+- No single industry may exceed {max_industry_weight:.0%} of the total portfolio
+
+CANDIDATES (top {n} by screening score, sorted descending):
+{candidates_text}
+
+Select the best {max_holdings} holdings. Higher-conviction picks should receive higher weights.
+Write a one-sentence thesis per holding. Include a 2-3 sentence portfolio thesis explaining
+the overall composition and the main themes.
+
+Respond with valid JSON only, no markdown fences:
+{{
+  "holdings": [
+    {{"ticker": "<str>", "weight": <float>, "sector": "<str>",
+      "industry": "<str>", "thesis": "<str>"}}
+  ],
+  "industry_breakdown": {{"<industry>": <float>}},
+  "portfolio_thesis": "<str>"
+}}
+"""
+
+_REBALANCE_PROMPT = """\
+You are a portfolio manager deciding which trades to execute this month.
+
+LIVE PORTFOLIO (what is currently held):
+{current_text}
+
+PROPOSED PORTFOLIO (what the model wants):
+{proposed_text}
+
+Continuity note: existing holdings have had their scores boosted by {continuity_bonus:.2f}
+points (on a 10-point scale) to represent avoided transaction costs. Only replace a current
+holding if the new candidate meaningfully outperforms net of this friction.
+
+For each ticker that appears in either portfolio, specify an action:
+  BUY      - open a new position not currently held
+  SELL     - exit a position entirely
+  HOLD     - keep at current weight, no trade needed
+  INCREASE - add to an existing position (provide target_weight)
+  DECREASE - trim an existing position (provide target_weight)
+
+Respond with valid JSON only, no markdown fences:
+{{
+  "trades": [
+    {{"ticker": "<str>", "action": "<str>",
+      "current_weight": <float or null>, "target_weight": <float or null>,
+      "reasoning": "<str>"}}
+  ],
+  "estimated_turnover_pct": <float>
+}}
+"""
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _load_partitioned(dataset: dict[str, Any], key: str) -> pd.DataFrame | None:
+    """Load one partition from a partitioned dataset, returning None on failure."""
+    if key not in dataset:
+        return None
+    try:
+        val = dataset[key]
+        return val() if callable(val) else val
+    except Exception:
+        logger.warning("Could not load partition %s.", key)
+        return None
+
+
+# ── Node functions ────────────────────────────────────────────────────────────
+
+
+def score_tickers(
+    valuation_ratios: dict[str, Callable[[], pd.DataFrame]],
+    analyst_consensus: dict[str, Callable[[], pd.DataFrame]],
+    earnings_history: dict[str, Callable[[], pd.DataFrame]],
+    company_info: dict[str, Callable[[], pd.DataFrame]],
+    company_financials: dict[str, Callable[[], pd.DataFrame]],
+    stock_analyses: dict[str, Any],
+    news_analysis: dict[str, Any],
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Stage 1: call Claude Haiku once per ticker to score the full universe.
+
+    Merges all available data sources into a compact ticker brief, then asks
+    Claude to assign a score (1-10), a verdict (STRONG_BUY / BUY / HOLD / AVOID),
+    and a one-sentence thesis. Tickers with no data at all are skipped.
+    API failures per ticker are logged and that ticker is skipped.
+
+    Args:
+        valuation_ratios: Partitioned valuation ratio DataFrames per ticker.
+        analyst_consensus: Partitioned analyst consensus DataFrames per ticker.
+        earnings_history: Partitioned earnings history DataFrames per ticker.
+        company_info: Partitioned company info DataFrames per ticker.
+        company_financials: Partitioned quarterly financials DataFrames per ticker.
+        stock_analyses: Plain dict of strategy signal dicts keyed by ticker.
+        news_analysis: Partitioned news analysis JSON dicts per ticker.
+        params: ``portfolio_construction`` parameter block.
+
+    Returns:
+        Dict keyed by lowercase ticker with score, verdict, thesis, scored_at.
+    """
+    model = str(params["model_screening"])
+    max_tokens = int(params.get("max_tokens_screening", 512))
+
+    all_keys: set[str] = set()
+    for ds in (
+        valuation_ratios,
+        analyst_consensus,
+        earnings_history,
+        company_info,
+        company_financials,
+    ):
+        all_keys.update(ds.keys())
+    all_keys.update(k.lower() for k in stock_analyses)
+    all_keys.update(k.lower() for k in news_analysis)
+
+    client = _make_client()
+    result: dict[str, Any] = {}
+
+    for key in sorted(all_keys):
+        ticker = key.upper()
+
+        info_df = _load_partitioned(company_info, key)
+        val_df = _load_partitioned(valuation_ratios, key)
+        cons_df = _load_partitioned(analyst_consensus, key)
+        earn_df = _load_partitioned(earnings_history, key)
+        fin_df = _load_partitioned(company_financials, key)
+
+        signals = stock_analyses.get(key) or stock_analyses.get(ticker)
+
+        news_entry = None
+        if key in news_analysis:
+            try:
+                raw = news_analysis[key]
+                news_entry = raw() if callable(raw) else raw
+            except Exception:
+                logger.warning("Could not load news analysis for %s.", ticker)
+
+        brief = _build_ticker_brief(
+            ticker=ticker,
+            info=info_df,
+            valuation=val_df,
+            consensus=cons_df,
+            earnings=earn_df,
+            financials=fin_df,
+            strategy_signals=signals,
+            news=news_entry,
+        )
+
+        try:
+            raw_response = _call_claude(
+                client,
+                _SCORE_PROMPT.format(ticker=ticker, brief=brief),
+                model,
+                max_tokens,
+            )
+            scored = _parse_json_response(raw_response)
+            result[key] = {
+                "ticker": ticker,
+                "score": float(scored["score"]),
+                "verdict": str(scored["verdict"]),
+                "thesis": str(scored["thesis"]),
+                "scored_at": pd.Timestamp.now("UTC").strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+        except Exception:
+            logger.warning("Scoring failed for %s — skipping.", ticker, exc_info=True)
+
+    logger.info("Scored %d tickers.", len(result))
+    return result
+
+
+def construct_portfolio(
+    ticker_scores: dict[str, Any],
+    company_info: dict[str, Callable[[], pd.DataFrame]],
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Stage 2: single Claude Sonnet call to select 10 holdings with weights.
+
+    Takes the top-N scored tickers, enriches each with sector/industry from
+    company_info, and asks Claude to build a constraint-satisfying portfolio.
+    Weights are conviction-proportional (5-20% per position, sum to 1.0).
+
+    Args:
+        ticker_scores: Output of score_tickers — dict keyed by lowercase ticker.
+        company_info: Partitioned company info DataFrames per ticker.
+        params: ``portfolio_construction`` parameter block.
+
+    Returns:
+        Portfolio dict with holdings, industry_breakdown, portfolio_thesis, generated_at.
+    """
+    model = str(params["model_selection"])
+    max_tokens = int(params.get("max_tokens_selection", 4096))
+    top_n = int(params.get("top_n_candidates", 30))
+    max_holdings = int(params.get("max_holdings", 10))
+    max_industry_weight = float(params.get("max_industry_weight", 0.35))
+    min_weight = float(params.get("min_position_weight", 0.05))
+    max_weight = float(params.get("max_position_weight", 0.20))
+
+    ranked = sorted(ticker_scores.values(), key=lambda x: x["score"], reverse=True)[
+        :top_n
+    ]
+
+    def _sector_info(key: str) -> tuple[str, str, str]:
+        df = _load_partitioned(company_info, key)
+        if df is None or df.empty:
+            return "Unknown", "Unknown", "n/a"
+        row = df.iloc[0]
+        mcap = row.get("market_cap")
+        mcap_str = f"${mcap / 1e9:.1f}B" if pd.notna(mcap) else "n/a"
+        return (
+            str(row.get("sector") or "Unknown"),
+            str(row.get("industry") or "Unknown"),
+            mcap_str,
+        )
+
+    candidate_lines = []
+    for i, cand in enumerate(ranked, 1):
+        sector, industry, mcap = _sector_info(cand["ticker"].lower())
+        candidate_lines.append(
+            f"{i:2}. {cand['ticker']:<6} score={cand['score']:.1f}"
+            f" verdict={cand['verdict']}"
+            f" | {sector} / {industry} | mkt cap {mcap}"
+            f"\n    {cand['thesis']}"
+        )
+
+    prompt = _SELECT_PROMPT.format(
+        max_holdings=max_holdings,
+        min_weight=min_weight,
+        max_weight=max_weight,
+        max_industry_weight=max_industry_weight,
+        n=len(ranked),
+        candidates_text="\n".join(candidate_lines),
+    )
+
+    client = _make_client()
+    raw = _call_claude(client, prompt, model, max_tokens)
+    portfolio = _parse_json_response(raw)
+    portfolio["generated_at"] = pd.Timestamp.now("UTC").strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    logger.info(
+        "Portfolio constructed: %d holdings.", len(portfolio.get("holdings", []))
+    )
+    return portfolio
+
+
+def rebalance_portfolio(
+    portfolio_allocation: dict[str, Any],
+    live_portfolio: dict[str, Any],
+    ticker_scores: dict[str, Any],
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Stage 3: single Claude Haiku call deciding which trades to execute.
+
+    Compares the freshly constructed portfolio against the live portfolio
+    (what is actually held). Applies a continuity bonus to existing holdings
+    so the model prefers holding over replacing unless a new candidate clearly
+    outperforms net of transaction friction.
+
+    On the first run (live_portfolio == {}), all proposed holdings become BUY trades.
+
+    Args:
+        portfolio_allocation: Output of construct_portfolio for this run.
+        live_portfolio: Current live holdings from NullableJSONDataset (empty on first run).
+        ticker_scores: Output of score_tickers — used to surface adjusted scores.
+        params: ``portfolio_construction`` parameter block.
+
+    Returns:
+        Dict with trades list, estimated_turnover_pct, rebalanced_at.
+    """
+    model = str(params["model_rebalancing"])
+    max_tokens = int(params.get("max_tokens_rebalancing", 2048))
+    continuity_bonus = float(params.get("continuity_bonus", 0.08))
+
+    current_holdings = live_portfolio.get("holdings", [])
+
+    if not current_holdings:
+        trades = [
+            {
+                "ticker": h["ticker"],
+                "action": "BUY",
+                "current_weight": None,
+                "target_weight": h["weight"],
+                "reasoning": "Initial portfolio construction — no prior holdings.",
+            }
+            for h in portfolio_allocation.get("holdings", [])
+        ]
+        return {
+            "trades": trades,
+            "estimated_turnover_pct": 100.0,
+            "rebalanced_at": pd.Timestamp.now("UTC").strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+
+    current_tickers = {h["ticker"].upper() for h in current_holdings}
+    adjusted_scores: dict[str, float] = {
+        scored["ticker"]: min(
+            10.0,
+            scored["score"]
+            + (
+                continuity_bonus * 10
+                if scored["ticker"].upper() in current_tickers
+                else 0.0
+            ),
+        )
+        for scored in ticker_scores.values()
+    }
+
+    def _holdings_text(holdings: list[dict[str, Any]]) -> str:
+        lines = []
+        for h in holdings:
+            adj = adjusted_scores.get(h["ticker"], "n/a")
+            adj_str = f"{adj:.1f}" if isinstance(adj, float) else str(adj)
+            lines.append(
+                f"  {h['ticker']:<6} weight={h['weight']:.1%}"
+                f" | {h.get('sector', '?')} / {h.get('industry', '?')}"
+                f" | adj score={adj_str}"
+                f" | {h.get('thesis', '')}"
+            )
+        return "\n".join(lines)
+
+    prompt = _REBALANCE_PROMPT.format(
+        current_text=_holdings_text(current_holdings),
+        proposed_text=_holdings_text(portfolio_allocation.get("holdings", [])),
+        continuity_bonus=continuity_bonus * 10,
+    )
+
+    client = _make_client()
+    raw = _call_claude(client, prompt, model, max_tokens)
+    decision = _parse_json_response(raw)
+    decision["rebalanced_at"] = pd.Timestamp.now("UTC").strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    logger.info(
+        "Rebalancing: %d trades, ~%.1f%% turnover.",
+        len(decision.get("trades", [])),
+        decision.get("estimated_turnover_pct", 0.0),
+    )
+    return decision

--- a/src/rdd/pipelines/portfolio_construction/pipeline.py
+++ b/src/rdd/pipelines/portfolio_construction/pipeline.py
@@ -1,0 +1,53 @@
+"""Portfolio construction pipeline — three Claude agent stages."""
+
+from kedro.pipeline import Pipeline, node
+
+from rdd.pipelines.portfolio_construction.nodes import (
+    construct_portfolio,
+    rebalance_portfolio,
+    score_tickers,
+)
+
+
+def create_pipeline(**_kwargs) -> Pipeline:
+    """Create the portfolio_construction pipeline."""
+    return Pipeline(
+        nodes=[
+            node(
+                func=score_tickers,
+                inputs=[
+                    "raw_valuation_ratios",
+                    "raw_analyst_consensus",
+                    "raw_earnings_history",
+                    "raw_company_info",
+                    "raw_company_financials_quarterly",
+                    "stock_analyses",
+                    "raw_news_analysis_existing",
+                    "params:portfolio_construction",
+                ],
+                outputs="portfolio_ticker_scores",
+                name="score_tickers",
+            ),
+            node(
+                func=construct_portfolio,
+                inputs=[
+                    "portfolio_ticker_scores",
+                    "raw_company_info",
+                    "params:portfolio_construction",
+                ],
+                outputs="portfolio_allocation",
+                name="construct_portfolio",
+            ),
+            node(
+                func=rebalance_portfolio,
+                inputs=[
+                    "portfolio_allocation",
+                    "live_portfolio",
+                    "portfolio_ticker_scores",
+                    "params:portfolio_construction",
+                ],
+                outputs="portfolio_trades",
+                name="rebalance_portfolio",
+            ),
+        ]
+    )

--- a/tests/pipelines/portfolio_construction/test_nodes.py
+++ b/tests/pipelines/portfolio_construction/test_nodes.py
@@ -1,0 +1,498 @@
+"""Unit tests for portfolio_construction nodes."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from rdd.pipelines.portfolio_construction.nodes import (
+    _build_ticker_brief,
+    construct_portfolio,
+    rebalance_portfolio,
+    score_tickers,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+
+@pytest.fixture
+def base_params() -> dict[str, Any]:
+    return {
+        "model_screening": "claude-haiku-4-5-20251001",
+        "model_selection": "claude-sonnet-4-6",
+        "model_rebalancing": "claude-haiku-4-5-20251001",
+        "max_tokens_screening": 512,
+        "max_tokens_selection": 4096,
+        "max_tokens_rebalancing": 2048,
+        "top_n_candidates": 10,
+        "max_holdings": 3,
+        "max_industry_weight": 0.35,
+        "min_position_weight": 0.05,
+        "max_position_weight": 0.50,
+        "continuity_bonus": 0.08,
+    }
+
+
+def _make_info_df(
+    ticker: str = "AAPL",
+    sector: str = "Technology",
+    industry: str = "Consumer Electronics",
+    market_cap: float = 3e12,
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "ticker": ticker,
+                "name": f"{ticker} Inc.",
+                "sector": sector,
+                "industry": industry,
+                "market_cap": market_cap,
+                "employees": 100_000.0,
+                "country": "United States",
+                "currency": "USD",
+                "exchange": "NMS",
+                "fetched_at": pd.Timestamp("2024-01-02"),
+            }
+        ]
+    )
+
+
+def _make_valuation_df(ticker: str = "AAPL") -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "ticker": ticker,
+                "period_end": pd.Timestamp("2024-01-01"),
+                "pe_ratio": 28.5,
+                "pb_ratio": 4.2,
+                "ev_ebitda": 18.0,
+                "gross_margin": 0.44,
+                "operating_margin": 0.30,
+                "free_cash_flow_yield": 0.035,
+                "market_cap": 3e12,
+                "roe": 0.15,
+                "roa": 0.08,
+                "debt_to_equity": 0.3,
+                "net_margin": 0.25,
+                "fetched_at": pd.Timestamp("2024-01-02"),
+            }
+        ]
+    )
+
+
+def _make_consensus_df(ticker: str = "AAPL") -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "ticker": ticker,
+                "recommendation_key": "buy",
+                "recommendation_mean": 2.1,
+                "analyst_count": 35.0,
+                "target_mean_price": 250.0,
+                "target_high_price": 300.0,
+                "target_low_price": 200.0,
+                "target_median_price": 250.0,
+                "current_price": 220.0,
+                "fetched_at": pd.Timestamp("2024-01-02"),
+            }
+        ]
+    )
+
+
+def _make_earnings_df(ticker: str = "AAPL") -> pd.DataFrame:
+    dates = pd.date_range("2023-01-01", periods=4, freq="QE")
+    return pd.DataFrame(
+        {
+            "ticker": [ticker] * 4,
+            "earnings_date": dates,
+            "eps_estimate": [1.0, 1.1, 1.2, 1.3],
+            "reported_eps": [1.05, 1.15, 1.18, 1.35],
+            "surprise_pct": [5.0, 4.5, -1.7, 3.8],
+            "fetched_at": pd.Timestamp("2024-01-02"),
+        }
+    )
+
+
+def _make_financials_df(ticker: str = "AAPL") -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "ticker": ticker,
+                "period_end": pd.Timestamp("2023-12-31"),
+                "total_revenue": 120e9,
+                "gross_profit": 55e9,
+                "operating_income": 35e9,
+                "net_income": 30e9,
+                "ebitda": 40e9,
+                "ebit": 35e9,
+                "diluted_eps": 1.3,
+                "basic_eps": 1.35,
+                "cost_of_revenue": 65e9,
+                "research_and_development": 8e9,
+                "selling_general_and_administration": 12e9,
+                "pretax_income": 32e9,
+                "tax_provision": 2e9,
+                "total_assets": 300e9,
+                "total_liabilities": 250e9,
+                "equity": 50e9,
+                "total_debt": 100e9,
+                "cash_and_equivalents": 30e9,
+                "net_debt": 70e9,
+                "working_capital": 20e9,
+                "net_ppe": 40e9,
+                "accounts_receivable": 15e9,
+                "inventory": 5e9,
+                "accounts_payable": 10e9,
+                "long_term_debt": 80e9,
+                "free_cash_flow": 25e9,
+                "operating_cash_flow": 32e9,
+                "capital_expenditure": -7e9,
+                "cash_dividends_paid": -5e9,
+                "stock_based_compensation": 3e9,
+                "depreciation_and_amortization": 5e9,
+                "net_long_term_debt_issuance": -10e9,
+                "repurchase_of_capital_stock": -20e9,
+                "fetched_at": pd.Timestamp("2024-01-02"),
+            }
+        ]
+    )
+
+
+def _mock_claude(mocker, response: str) -> MagicMock:
+    mock_client = MagicMock()
+    mock_msg = MagicMock()
+    mock_msg.content = [MagicMock(text=response)]
+    mock_client.messages.create.return_value = mock_msg
+    mocker.patch(
+        "rdd.pipelines.portfolio_construction.nodes.anthropic.Anthropic",
+        return_value=mock_client,
+    )
+    return mock_client
+
+
+# ── _build_ticker_brief ───────────────────────────────────────────────────────
+
+
+class TestBuildTickerBrief:
+    def test_all_sources_present(self) -> None:
+        brief = _build_ticker_brief(
+            ticker="AAPL",
+            info=_make_info_df(),
+            valuation=_make_valuation_df(),
+            consensus=_make_consensus_df(),
+            earnings=_make_earnings_df(),
+            financials=_make_financials_df(),
+            strategy_signals={
+                "ticker": "AAPL",
+                "signals": [
+                    {"strategy": "momentum", "direction": "bullish", "metrics": {}},
+                    {"strategy": "trend", "direction": "bearish", "metrics": {}},
+                ],
+            },
+            news={
+                "bull_report": "We rate AAPL a BUY (conviction 4/5) with a price target of $280."
+            },
+        )
+        assert "AAPL" in brief
+        assert "Technology" in brief
+        assert "momentum: bullish" in brief
+        assert "P/E" in brief
+        assert "Revenue" in brief
+        assert "buy" in brief
+        assert "conviction 4/5" in brief
+
+    def test_all_sources_none(self) -> None:
+        brief = _build_ticker_brief(
+            ticker="AAPL",
+            info=None,
+            valuation=None,
+            consensus=None,
+            earnings=None,
+            financials=None,
+            strategy_signals=None,
+            news=None,
+        )
+        assert "AAPL" in brief
+
+    def test_empty_dataframes(self) -> None:
+        brief = _build_ticker_brief(
+            ticker="MSFT",
+            info=pd.DataFrame(),
+            valuation=pd.DataFrame(),
+            consensus=pd.DataFrame(),
+            earnings=pd.DataFrame(),
+            financials=pd.DataFrame(),
+            strategy_signals=None,
+            news=None,
+        )
+        assert "MSFT" in brief
+
+
+# ── score_tickers ─────────────────────────────────────────────────────────────
+
+
+class TestScoreTickers:
+    def test_scores_tickers_successfully(self, mocker, base_params) -> None:
+        _mock_claude(
+            mocker,
+            '{"score": 7.5, "verdict": "BUY", "thesis": "Strong fundamentals."}',
+        )
+        result = score_tickers(
+            valuation_ratios={"aapl": lambda: _make_valuation_df()},
+            analyst_consensus={"aapl": lambda: _make_consensus_df()},
+            earnings_history={"aapl": lambda: _make_earnings_df()},
+            company_info={"aapl": lambda: _make_info_df()},
+            company_financials={"aapl": lambda: _make_financials_df()},
+            stock_analyses={},
+            news_analysis={},
+            params=base_params,
+        )
+        assert "aapl" in result
+        assert result["aapl"]["score"] == 7.5
+        assert result["aapl"]["verdict"] == "BUY"
+        assert result["aapl"]["ticker"] == "AAPL"
+
+    def test_api_failure_skips_ticker(self, mocker, base_params) -> None:
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = RuntimeError("API error")
+        mocker.patch(
+            "rdd.pipelines.portfolio_construction.nodes.anthropic.Anthropic",
+            return_value=mock_client,
+        )
+        result = score_tickers(
+            valuation_ratios={"aapl": lambda: _make_valuation_df()},
+            analyst_consensus={},
+            earnings_history={},
+            company_info={"aapl": lambda: _make_info_df()},
+            company_financials={},
+            stock_analyses={},
+            news_analysis={},
+            params=base_params,
+        )
+        assert result == {}
+
+    def test_malformed_json_skips_ticker(self, mocker, base_params) -> None:
+        _mock_claude(mocker, "not valid json at all")
+        result = score_tickers(
+            valuation_ratios={"aapl": lambda: _make_valuation_df()},
+            analyst_consensus={},
+            earnings_history={},
+            company_info={},
+            company_financials={},
+            stock_analyses={},
+            news_analysis={},
+            params=base_params,
+        )
+        assert result == {}
+
+    def test_uses_news_analysis_partition(self, mocker, base_params) -> None:
+        _mock_claude(
+            mocker,
+            '{"score": 9.0, "verdict": "STRONG_BUY", "thesis": "News positive."}',
+        )
+        news_entry = {
+            "bull_report": "We rate AAPL a BUY with a 12-month target of $300 (conviction 5/5).",
+            "bear_report": "",
+        }
+        result = score_tickers(
+            valuation_ratios={},
+            analyst_consensus={},
+            earnings_history={},
+            company_info={},
+            company_financials={},
+            stock_analyses={},
+            news_analysis={"aapl": lambda: news_entry},
+            params=base_params,
+        )
+        assert "aapl" in result
+
+
+# ── construct_portfolio ───────────────────────────────────────────────────────
+
+
+class TestConstructPortfolio:
+    def _portfolio_response(self) -> str:
+        return """{
+            "holdings": [
+                {"ticker": "AAPL", "weight": 0.40, "sector": "Technology",
+                 "industry": "Consumer Electronics", "thesis": "Strong earnings."},
+                {"ticker": "MSFT", "weight": 0.35, "sector": "Technology",
+                 "industry": "Software", "thesis": "Cloud growth."},
+                {"ticker": "JNJ", "weight": 0.25, "sector": "Healthcare",
+                 "industry": "Drug Manufacturers", "thesis": "Stable dividends."}
+            ],
+            "industry_breakdown": {
+                "Consumer Electronics": 0.40,
+                "Software": 0.35,
+                "Drug Manufacturers": 0.25
+            },
+            "portfolio_thesis": "Diversified across tech and healthcare."
+        }"""
+
+    def test_returns_valid_portfolio(self, mocker, base_params) -> None:
+        _mock_claude(mocker, self._portfolio_response())
+        scores = {
+            "aapl": {
+                "ticker": "AAPL",
+                "score": 9.0,
+                "verdict": "STRONG_BUY",
+                "thesis": "t",
+            },
+            "msft": {"ticker": "MSFT", "score": 8.5, "verdict": "BUY", "thesis": "t"},
+            "jnj": {"ticker": "JNJ", "score": 7.0, "verdict": "BUY", "thesis": "t"},
+        }
+        result = construct_portfolio(
+            ticker_scores=scores,
+            company_info={"aapl": lambda: _make_info_df()},
+            params=base_params,
+        )
+        assert "holdings" in result
+        assert len(result["holdings"]) == 3
+        assert "generated_at" in result
+
+    def test_includes_generated_at(self, mocker, base_params) -> None:
+        _mock_claude(mocker, self._portfolio_response())
+        result = construct_portfolio(
+            ticker_scores={
+                "aapl": {
+                    "ticker": "AAPL",
+                    "score": 8.0,
+                    "verdict": "BUY",
+                    "thesis": "t",
+                }
+            },
+            company_info={},
+            params=base_params,
+        )
+        assert result["generated_at"].endswith("Z")
+
+
+# ── rebalance_portfolio ───────────────────────────────────────────────────────
+
+
+class TestRebalancePortfolio:
+    def _proposed(self) -> dict:
+        return {
+            "holdings": [
+                {
+                    "ticker": "AAPL",
+                    "weight": 0.50,
+                    "sector": "Technology",
+                    "industry": "Consumer Electronics",
+                    "thesis": "Growth.",
+                },
+                {
+                    "ticker": "NVDA",
+                    "weight": 0.50,
+                    "sector": "Technology",
+                    "industry": "Semiconductors",
+                    "thesis": "AI upside.",
+                },
+            ]
+        }
+
+    def test_first_run_all_buys(self, base_params) -> None:
+        result = rebalance_portfolio(
+            portfolio_allocation=self._proposed(),
+            live_portfolio={},
+            ticker_scores={},
+            params=base_params,
+        )
+        actions = {t["ticker"]: t["action"] for t in result["trades"]}
+        assert actions["AAPL"] == "BUY"
+        assert actions["NVDA"] == "BUY"
+        assert result["estimated_turnover_pct"] == 100.0
+
+    def test_normal_rebalance_calls_claude(self, mocker, base_params) -> None:
+        mock_client = _mock_claude(
+            mocker,
+            """{
+                "trades": [
+                    {"ticker": "AAPL", "action": "HOLD",
+                     "current_weight": 0.50, "target_weight": 0.50,
+                     "reasoning": "Unchanged."},
+                    {"ticker": "META", "action": "SELL",
+                     "current_weight": 0.50, "target_weight": null,
+                     "reasoning": "Score dropped."},
+                    {"ticker": "NVDA", "action": "BUY",
+                     "current_weight": null, "target_weight": 0.50,
+                     "reasoning": "New entry."}
+                ],
+                "estimated_turnover_pct": 50.0
+            }""",
+        )
+        live = {
+            "holdings": [
+                {
+                    "ticker": "AAPL",
+                    "weight": 0.50,
+                    "sector": "Technology",
+                    "industry": "Consumer Electronics",
+                    "thesis": "Growth.",
+                },
+                {
+                    "ticker": "META",
+                    "weight": 0.50,
+                    "sector": "Technology",
+                    "industry": "Social Media",
+                    "thesis": "Ads.",
+                },
+            ]
+        }
+        scores = {
+            "aapl": {"ticker": "AAPL", "score": 8.0, "verdict": "BUY", "thesis": "t"},
+            "meta": {"ticker": "META", "score": 5.0, "verdict": "HOLD", "thesis": "t"},
+            "nvda": {
+                "ticker": "NVDA",
+                "score": 9.0,
+                "verdict": "STRONG_BUY",
+                "thesis": "t",
+            },
+        }
+        result = rebalance_portfolio(
+            portfolio_allocation=self._proposed(),
+            live_portfolio=live,
+            ticker_scores=scores,
+            params=base_params,
+        )
+        assert mock_client.messages.create.called
+        assert result["estimated_turnover_pct"] == 50.0
+        assert "rebalanced_at" in result
+
+    def test_continuity_bonus_applied_to_existing(self, mocker, base_params) -> None:
+        """Existing holdings should have their scores boosted in the prompt text."""
+        mock_client = _mock_claude(
+            mocker,
+            '{"trades": [], "estimated_turnover_pct": 0.0}',
+        )
+        live = {
+            "holdings": [
+                {
+                    "ticker": "AAPL",
+                    "weight": 1.0,
+                    "sector": "Technology",
+                    "industry": "Consumer Electronics",
+                    "thesis": "t",
+                },
+            ]
+        }
+        scores = {
+            "aapl": {"ticker": "AAPL", "score": 7.0, "verdict": "BUY", "thesis": "t"},
+        }
+        rebalance_portfolio(
+            portfolio_allocation={"holdings": []},
+            live_portfolio=live,
+            ticker_scores=scores,
+            params=base_params,
+        )
+        prompt_sent = mock_client.messages.create.call_args[1]["messages"][0]["content"]
+        # Score 7.0 + 0.08*10 = 7.8 should appear in the prompt
+        assert "7.8" in prompt_sent

--- a/tests/pipelines/portfolio_construction/test_pipeline.py
+++ b/tests/pipelines/portfolio_construction/test_pipeline.py
@@ -1,0 +1,153 @@
+"""Integration tests for the portfolio_construction pipeline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import pytest
+from kedro.io import DataCatalog, MemoryDataset
+from kedro.runner import SequentialRunner
+
+from rdd.pipelines.portfolio_construction.pipeline import create_pipeline
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+
+@pytest.fixture
+def pipeline():
+    return create_pipeline()
+
+
+@pytest.fixture
+def params() -> dict[str, Any]:
+    return {
+        "model_screening": "claude-haiku-4-5-20251001",
+        "model_selection": "claude-sonnet-4-6",
+        "model_rebalancing": "claude-haiku-4-5-20251001",
+        "max_tokens_screening": 512,
+        "max_tokens_selection": 4096,
+        "max_tokens_rebalancing": 2048,
+        "top_n_candidates": 5,
+        "max_holdings": 2,
+        "max_industry_weight": 0.50,
+        "min_position_weight": 0.10,
+        "max_position_weight": 0.90,
+        "continuity_bonus": 0.08,
+    }
+
+
+def _mock_claude_responses(mocker) -> None:
+    score_resp = '{"score": 8.0, "verdict": "BUY", "thesis": "Strong fundamentals."}'
+    select_resp = """{
+        "holdings": [
+            {"ticker": "AAPL", "weight": 0.60, "sector": "Technology",
+             "industry": "Consumer Electronics", "thesis": "Leading hardware."},
+            {"ticker": "MSFT", "weight": 0.40, "sector": "Technology",
+             "industry": "Software", "thesis": "Cloud growth."}
+        ],
+        "industry_breakdown": {"Consumer Electronics": 0.60, "Software": 0.40},
+        "portfolio_thesis": "Tech-focused portfolio."
+    }"""
+    rebalance_resp = """{
+        "trades": [
+            {"ticker": "AAPL", "action": "BUY", "current_weight": null,
+             "target_weight": 0.60, "reasoning": "New entry."},
+            {"ticker": "MSFT", "action": "BUY", "current_weight": null,
+             "target_weight": 0.40, "reasoning": "New entry."}
+        ],
+        "estimated_turnover_pct": 100.0
+    }"""
+
+    responses = [score_resp, score_resp, select_resp, rebalance_resp]
+    call_count = {"n": 0}
+
+    def _side_effect(**kwargs):
+        resp = responses[min(call_count["n"], len(responses) - 1)]
+        call_count["n"] += 1
+        mock_msg = mocker.MagicMock()
+        mock_msg.content = [mocker.MagicMock(text=resp)]
+        return mock_msg
+
+    mock_client = mocker.MagicMock()
+    mock_client.messages.create.side_effect = _side_effect
+    mocker.patch(
+        "rdd.pipelines.portfolio_construction.nodes.anthropic.Anthropic",
+        return_value=mock_client,
+    )
+
+
+def _make_catalog(params: dict) -> DataCatalog:
+    info_df = pd.DataFrame(
+        [
+            {
+                "ticker": t,
+                "name": f"{t} Inc.",
+                "sector": "Technology",
+                "industry": "Consumer Electronics",
+                "market_cap": 1e12,
+                "employees": 50_000.0,
+                "country": "US",
+                "currency": "USD",
+                "exchange": "NMS",
+                "fetched_at": pd.Timestamp("2024-01-02"),
+            }
+            for t in ["AAPL", "MSFT"]
+        ]
+    )
+    return DataCatalog(
+        {
+            "raw_valuation_ratios": MemoryDataset(data={}),
+            "raw_analyst_consensus": MemoryDataset(data={}),
+            "raw_earnings_history": MemoryDataset(data={}),
+            "raw_company_info": MemoryDataset(
+                data={
+                    "aapl": lambda: info_df[info_df["ticker"] == "AAPL"],
+                    "msft": lambda: info_df[info_df["ticker"] == "MSFT"],
+                }
+            ),
+            "raw_company_financials_quarterly": MemoryDataset(data={}),
+            "stock_analyses": MemoryDataset(data={}),
+            "raw_news_analysis_existing": MemoryDataset(data={}),
+            "live_portfolio": MemoryDataset(data={}),
+            "portfolio_ticker_scores": MemoryDataset(),
+            "portfolio_allocation": MemoryDataset(),
+            "portfolio_trades": MemoryDataset(),
+            "params:portfolio_construction": MemoryDataset(data=params),
+        }
+    )
+
+
+def test_pipeline_runs_successfully(mocker, pipeline, params) -> None:
+    _mock_claude_responses(mocker)
+    catalog = _make_catalog(params)
+    SequentialRunner().run(pipeline, catalog)
+
+    trades = catalog.load("portfolio_trades")
+    assert "trades" in trades
+    assert "rebalanced_at" in trades
+
+
+def test_pipeline_first_run_all_buys(mocker, pipeline, params) -> None:
+    _mock_claude_responses(mocker)
+    catalog = _make_catalog(params)
+    SequentialRunner().run(pipeline, catalog)
+
+    trades = catalog.load("portfolio_trades")
+    assert all(t["action"] == "BUY" for t in trades["trades"])
+
+
+def test_portfolio_allocation_has_required_keys(mocker, pipeline, params) -> None:
+    _mock_claude_responses(mocker)
+    catalog = _make_catalog(params)
+    # Run only up to construct_portfolio so the intermediate dataset isn't
+    # released when rebalance_portfolio consumes it.
+    partial = pipeline.filter(to_nodes=["construct_portfolio"])
+    SequentialRunner().run(partial, catalog)
+
+    allocation = catalog.load("portfolio_allocation")
+    assert "holdings" in allocation
+    assert "generated_at" in allocation


### PR DESCRIPTION
## Summary

- Adds `portfolio_construction` pipeline at the same level as `feature_engineering`, with three Claude-driven nodes:
  - **score_tickers** (Haiku, ~N calls): collapses valuation, financials, analyst consensus, earnings history, strategy signals, and news analysis into a per-ticker score + verdict + thesis
  - **construct_portfolio** (Sonnet, 1 call): selects up to 10 long holdings with conviction-weighted positions (5–20% each), enforcing a 35% per-industry cap
  - **rebalance_portfolio** (Haiku, 1 call): compares the proposed allocation against the live portfolio and emits a trade list; existing holdings receive a continuity bonus to proxy avoided transaction costs
- Adds `NullableJSONDataset` — returns `{}` when the target file is missing, so the first-ever run (no live portfolio yet) short-circuits to all-BUY without errors
- Wires pipeline into `pipeline_registry.py` and CI

## Test plan

- [x] 15 unit + integration tests under `tests/pipelines/portfolio_construction/`
- [x] All pre-commit hooks pass (ruff lint, ruff format, whitespace, EOF)
- [ ] CI green on all existing jobs + new `Tests / Pipelines / portfolio_construction` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)