### PR TITLE
fix(cron): use checkout -f + reset --hard in all cron sync_branch calls

### DIFF
--- a/scripts/run_daily_ingest.sh
+++ b/scripts/run_daily_ingest.sh
@@ -101,8 +101,8 @@ send_report() {
 sync_branch() {
   log "[GIT] syncing to $CRON_BRANCH..."
   git -C "$PROJECT_ROOT" fetch origin "$CRON_BRANCH" >> "$LOG_FILE" 2>&1
-  git -C "$PROJECT_ROOT" checkout "$CRON_BRANCH" >> "$LOG_FILE" 2>&1
-  git -C "$PROJECT_ROOT" pull --ff-only origin "$CRON_BRANCH" >> "$LOG_FILE" 2>&1
+  git -C "$PROJECT_ROOT" checkout -f "$CRON_BRANCH" >> "$LOG_FILE" 2>&1
+  git -C "$PROJECT_ROOT" reset --hard "origin/$CRON_BRANCH" >> "$LOG_FILE" 2>&1
   log "[GIT] HEAD=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
 }
 

--- a/scripts/run_monthly_strategy.sh
+++ b/scripts/run_monthly_strategy.sh
@@ -26,8 +26,8 @@ main() {
 
   log "=== monthly strategy run start ==="
   git -C "$PROJECT_ROOT" fetch origin main >> "$LOG_FILE" 2>&1
-  git -C "$PROJECT_ROOT" checkout main >> "$LOG_FILE" 2>&1
-  git -C "$PROJECT_ROOT" pull --ff-only origin main >> "$LOG_FILE" 2>&1
+  git -C "$PROJECT_ROOT" checkout -f main >> "$LOG_FILE" 2>&1
+  git -C "$PROJECT_ROOT" reset --hard origin/main >> "$LOG_FILE" 2>&1
   log "[GIT] HEAD=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
 
   (cd "$PROJECT_ROOT" && uv run kedro run --pipeline ai_fundamental_screen) >> "$LOG_FILE" 2>&1

--- a/scripts/run_weekly_performance.sh
+++ b/scripts/run_weekly_performance.sh
@@ -27,8 +27,8 @@ main() {
 
   log "=== weekly performance run start ==="
   git -C "$PROJECT_ROOT" fetch origin main >> "$LOG_FILE" 2>&1
-  git -C "$PROJECT_ROOT" checkout main >> "$LOG_FILE" 2>&1
-  git -C "$PROJECT_ROOT" pull --ff-only origin main >> "$LOG_FILE" 2>&1
+  git -C "$PROJECT_ROOT" checkout -f main >> "$LOG_FILE" 2>&1
+  git -C "$PROJECT_ROOT" reset --hard origin/main >> "$LOG_FILE" 2>&1
   log "[GIT] HEAD=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
 
   (cd "$PROJECT_ROOT" && uv run kedro run --pipeline portfolio_performance) >> "$LOG_FILE" 2>&1


### PR DESCRIPTION
`git checkout main` aborts when tracked files have local modifications, causing the script to exit silently under set -euo pipefail. Force checkout + hard reset always lands on origin/main regardless of local state. Data artifacts are gitignored so they are unaffected.

## Description

Brief summary of what this PR changes and why.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [ ] Self-review completed
- [ ] Tests added / updated
- [ ] `uv run pre-commit run --all-files` passes locally
- [ ] `uv run pytest` passes locally
- [ ] No data files committed (`data/`, `*.parquet`, `*.csv`)
- [ ] No secrets or API keys in code or config
