### PR TITLE
feat(cron): email alert on cron job failure via EXIT trap

### DIFF
--- a/scripts/run_daily_ingest.sh
+++ b/scripts/run_daily_ingest.sh
@@ -18,6 +18,7 @@ LOG_DIR="$PROJECT_ROOT/logs"
 LOG_FILE="$LOG_DIR/daily_ingest.log"
 DRY_RUN=false
 CRON_BRANCH="main"
+_DONE=false
 
 export PATH="/Users/Paul_Mora/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
@@ -32,6 +33,23 @@ ts() { date -u "+%Y-%m-%dT%H:%M:%SZ"; }
 log() {
   echo "[$(ts)] $*" | tee -a "$LOG_FILE"
 }
+
+_on_exit() {
+  local rc=$?
+  if [[ $rc -ne 0 ]] && ! $_DONE; then
+    log "[ALERT] script exited early (exit $rc) — sending failure alert..."
+    if [[ -f "$PROJECT_ROOT/.env" ]] && [[ -z "${RDD_SMTP_USER:-}" ]]; then
+      set -a
+      # shellcheck source=/dev/null
+      source "$PROJECT_ROOT/.env"
+      set +a
+    fi
+    (cd "$PROJECT_ROOT" && uv run python scripts/send_alert.py \
+      --subject "[RDD] run_daily_ingest.sh crashed (exit $rc)" \
+      --log "$LOG_FILE") >> "$LOG_FILE" 2>&1 || true
+  fi
+}
+trap '_on_exit' EXIT
 
 # Parallel arrays collecting results for the email report.
 PIPELINE_NAMES=()
@@ -133,6 +151,7 @@ main() {
     send_report
   fi
 
+  _DONE=true
   log "=== [DONE] ==="
 }
 

--- a/scripts/run_monthly_strategy.sh
+++ b/scripts/run_monthly_strategy.sh
@@ -16,6 +16,22 @@ mkdir -p "$LOG_DIR"
 ts() { date -u "+%Y-%m-%dT%H:%M:%SZ"; }
 log() { echo "[$(ts)] $*" | tee -a "$LOG_FILE"; }
 
+_on_exit() {
+  local rc=$?
+  [[ $rc -eq 0 ]] && return
+  log "[ALERT] script failed (exit $rc) — sending failure alert..."
+  if [[ -f "$PROJECT_ROOT/.env" ]] && [[ -z "${RDD_SMTP_USER:-}" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/.env"
+    set +a
+  fi
+  (cd "$PROJECT_ROOT" && uv run python scripts/send_alert.py \
+    --subject "[RDD] run_monthly_strategy.sh FAILED (exit $rc)" \
+    --log "$LOG_FILE") >> "$LOG_FILE" 2>&1 || true
+}
+trap '_on_exit' EXIT
+
 main() {
   if [[ -f "$PROJECT_ROOT/.env" ]]; then
     set -a

--- a/scripts/run_weekly_performance.sh
+++ b/scripts/run_weekly_performance.sh
@@ -17,6 +17,22 @@ mkdir -p "$LOG_DIR"
 ts() { date -u "+%Y-%m-%dT%H:%M:%SZ"; }
 log() { echo "[$(ts)] $*" | tee -a "$LOG_FILE"; }
 
+_on_exit() {
+  local rc=$?
+  [[ $rc -eq 0 ]] && return
+  log "[ALERT] script failed (exit $rc) — sending failure alert..."
+  if [[ -f "$PROJECT_ROOT/.env" ]] && [[ -z "${RDD_SMTP_USER:-}" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/.env"
+    set +a
+  fi
+  (cd "$PROJECT_ROOT" && uv run python scripts/send_alert.py \
+    --subject "[RDD] run_weekly_performance.sh FAILED (exit $rc)" \
+    --log "$LOG_FILE") >> "$LOG_FILE" 2>&1 || true
+}
+trap '_on_exit' EXIT
+
 main() {
   if [[ -f "$PROJECT_ROOT/.env" ]]; then
     set -a

--- a/scripts/send_alert.py
+++ b/scripts/send_alert.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Send a minimal failure alert email via Gmail SMTP.
+
+Called by cron scripts via a bash EXIT trap whenever a job exits non-zero
+before its normal completion path.
+
+Usage:
+    send_alert.py --subject "..." --log /path/to/job.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import smtplib
+import ssl
+import sys
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from pathlib import Path
+
+_LOG_TAIL = 80
+
+
+def _tail(path: str, n: int = _LOG_TAIL) -> str:
+    """Return the last *n* lines of *path*, or a placeholder if missing."""
+    p = Path(path)
+    if not p.exists():
+        return "(log file not found)"
+    lines = p.read_text().splitlines()
+    return "\n".join(lines[-n:]) if lines else "(empty log)"
+
+
+def _build_html(subject: str, log_tail: str) -> str:
+    """Return an HTML email body for a failure alert."""
+    log_section = (
+        f"<h3>Last log lines</h3>"
+        f"<pre style='font-size:11px;background:#f8f8f8;padding:12px'>{log_tail}</pre>"
+        if log_tail
+        else ""
+    )
+    return (
+        "<html><body style='font-family:sans-serif;max-width:800px'>"
+        f"<h2 style='color:#c0392b'>{subject}</h2>"
+        f"{log_section}"
+        "</body></html>"
+    )
+
+
+def main() -> None:
+    """Send failure alert email."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--subject", required=True, help="Email subject line")
+    parser.add_argument("--log", default=None, help="Path to the job log file")
+    args = parser.parse_args()
+
+    to_addr = os.environ.get("RDD_EMAIL_TO", "")
+    smtp_host = os.environ.get("RDD_SMTP_HOST", "smtp.gmail.com")
+    smtp_port = int(os.environ.get("RDD_SMTP_PORT", "465"))
+    smtp_user = os.environ.get("RDD_SMTP_USER", "")
+    smtp_pass = os.environ.get("RDD_SMTP_PASS", "")
+
+    if not all([to_addr, smtp_user, smtp_pass]):
+        sys.exit(
+            "Missing SMTP credentials (RDD_EMAIL_TO / RDD_SMTP_USER / RDD_SMTP_PASS)"
+        )
+
+    log_tail = _tail(args.log) if args.log else ""
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = args.subject
+    msg["From"] = smtp_user
+    msg["To"] = to_addr
+    msg.attach(MIMEText(_build_html(args.subject, log_tail), "html"))
+
+    ctx = ssl.create_default_context()
+    with smtplib.SMTP_SSL(smtp_host, smtp_port, context=ctx, timeout=30) as conn:
+        conn.login(smtp_user, smtp_pass)
+        conn.send_message(msg)
+
+    sys.stdout.write(f"Alert sent to {to_addr}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/send_report.py
+++ b/scripts/send_report.py
@@ -329,7 +329,11 @@ def _make_chart(history: dict[date, dict], membership: dict[str, set[str]]) -> b
 def _make_company_info_chart(history: dict[date, dict], universe_size: int) -> bytes:
     """Render company info snapshot coverage over time as a PNG."""
     today = date.today()
-    dates = sorted(d for d in history if d <= today)
+    # Exclude OHLCV-backfill entries that have no company-info data (n_company_info == 0
+    # on those entries is a default, not a real observation).
+    dates = sorted(
+        d for d in history if d <= today and history[d].get("n_company_info", 0) > 0
+    )
     counts = [history[d].get("n_company_info", 0) for d in dates]
 
     fig, ax = plt.subplots(figsize=(10, 3))
@@ -368,7 +372,13 @@ def _make_company_info_chart(history: dict[date, dict], universe_size: int) -> b
 def _make_company_news_chart(history: dict[date, dict]) -> bytes:
     """Render company news coverage over time (tickers covered + cumulative articles)."""
     today = date.today()
-    dates = sorted(d for d in history if d <= today)
+    # Exclude OHLCV-backfill entries that have no news data (n_company_news_tickers == 0
+    # on those entries is a default, not a real observation).
+    dates = sorted(
+        d
+        for d in history
+        if d <= today and history[d].get("n_company_news_tickers", 0) > 0
+    )
     tickers = [history[d].get("n_company_news_tickers", 0) for d in dates]
     articles = [history[d].get("n_company_news_articles", 0) for d in dates]
 


### PR DESCRIPTION
Adds scripts/send_alert.py (minimal SMTP failure email) and wires an EXIT trap into all three cron scripts so any unexpected exit — including git sync failures that occur before send_report is called — triggers an immediate [RDD] ... FAILED email with the last 80 lines of the job log.

## Description

Brief summary of what this PR changes and why.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [ ] Self-review completed
- [ ] Tests added / updated
- [ ] `uv run pre-commit run --all-files` passes locally
- [ ] `uv run pytest` passes locally
- [ ] No data files committed (`data/`, `*.parquet`, `*.csv`)
- [ ] No secrets or API keys in code or config
