### PR TITLE
feat(docs): add README with schedule overview; wire news analysis int…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ bash scripts/install_launchd.sh
 | `com.rdd.daily-ingest` | Mon–Fri 10:00 local | `run_daily_ingest.sh` | Fetches OHLCV, company info, news, financials, valuation ratios, analyst consensus, earnings history. Sends a summary email on completion. |
 | `com.rdd.weekly-performance` | Every Friday 12:00 local | `run_weekly_performance.sh` | Runs the portfolio performance pipeline and emails a report with a 3-month cumulative-return chart, KPI table, and holdings breakdown. |
 | `com.rdd.monthly-strategy` | 1st of each month 12:00 local | `run_monthly_strategy.sh` | Runs the `ai_fundamental_screen` strategy: Claude Haiku scores ~500 S&P 500 tickers on fundamentals, Claude Sonnet selects a concentrated 10-stock portfolio, and rebalancing trades are logged. |
-| `com.rdd.monthly-news-analysis` | 26th of each month 12:00 local | `run_monthly_news_analysis.sh` | Runs the `news_analysis` pipeline: generates AI-powered bull/bear research reports for each ticker using recent news and financials. |
+| `com.rdd.weekly-news-analysis` | Every Friday 12:00 local | `run_weekly_news_analysis.sh` | Runs the `news_analysis` pipeline: generates AI-powered bull/bear research reports for each ticker using recent news and financials. |
 
 All jobs sync to `main` before running (force checkout + hard reset) and send a failure alert email if they exit non-zero.
 
@@ -40,7 +40,7 @@ All jobs sync to `main` before running (force checkout + hard reset) and send a 
 | `strategies` | On-demand | Feature engineering and signal computation |
 | `ai_fundamental_screen` | Monthly (1st) | AI portfolio construction — scoring, selection, rebalancing |
 | `portfolio_performance` | Weekly (Friday) | Cumulative returns, Sharpe, max drawdown per strategy |
-| `news_analysis` | Monthly (26th) | AI bull/bear research reports per ticker |
+| `news_analysis` | Weekly (Friday) | AI bull/bear research reports per ticker |
 
 ## Logs
 
@@ -51,7 +51,7 @@ All job logs land in `logs/` (gitignored):
 | `logs/daily_ingest.log` | Daily ingest |
 | `logs/weekly_performance.log` | Weekly performance |
 | `logs/monthly_strategy.log` | Monthly strategy |
-| `logs/monthly_news_analysis.log` | Monthly news analysis |
+| `logs/weekly_news_analysis.log` | Weekly news analysis |
 | `logs/launchd.log` | launchd stdout/stderr |
 | `logs/run_manifest.jsonl` | Per-run OHLCV/news counts (used by report charts) |
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# Rubber Duck Debugger
+
+An algorithmic trading research platform for stock prediction and strategy testing. Connects to a live broker API, runs automated data ingestion pipelines, and generates AI-powered portfolio construction and market analysis.
+
+## Architecture
+
+```
+data ingestion  →  feature engineering  →  strategies  →  portfolio performance
+(daily, auto)       (valuation ratios)    (monthly, AI)    (weekly email)
+```
+
+## Automated Jobs
+
+All jobs run via macOS launchd. Install with:
+
+```bash
+bash scripts/install_launchd.sh
+```
+
+| Agent | Schedule | Script | What it does |
+|---|---|---|---|
+| `com.rdd.daily-ingest` | Mon–Fri 10:00 local | `run_daily_ingest.sh` | Fetches OHLCV, company info, news, financials, valuation ratios, analyst consensus, earnings history. Sends a summary email on completion. |
+| `com.rdd.weekly-performance` | Every Friday 12:00 local | `run_weekly_performance.sh` | Runs the portfolio performance pipeline and emails a report with a 3-month cumulative-return chart, KPI table, and holdings breakdown. |
+| `com.rdd.monthly-strategy` | 1st of each month 12:00 local | `run_monthly_strategy.sh` | Runs the `ai_fundamental_screen` strategy: Claude Haiku scores ~500 S&P 500 tickers on fundamentals, Claude Sonnet selects a concentrated 10-stock portfolio, and rebalancing trades are logged. |
+| `com.rdd.monthly-news-analysis` | 26th of each month 12:00 local | `run_monthly_news_analysis.sh` | Runs the `news_analysis` pipeline: generates AI-powered bull/bear research reports for each ticker using recent news and financials. |
+
+All jobs sync to `main` before running (force checkout + hard reset) and send a failure alert email if they exit non-zero.
+
+## Data Pipelines (Kedro)
+
+| Pipeline | Trigger | Output |
+|---|---|---|
+| `stock_prices` | Daily | OHLCV parquets per ticker, incremental from last stored date |
+| `company_info` | Daily | Snapshot parquet per ticker (sector, market cap, employees, …) |
+| `company_news` | Daily | Cumulative news parquets per ticker via Finnhub, incremental |
+| `company_financials` | Daily | Quarterly + annual financials per ticker via yfinance, refreshed every 7 days |
+| `valuation_ratios` | Daily | P/E, P/B, EV/EBITDA, etc. derived from financials + OHLCV |
+| `analyst_consensus` | Daily | Wall Street buy/hold/sell ratings per ticker |
+| `earnings_history` | Daily | Historical EPS surprises per ticker |
+| `strategies` | On-demand | Feature engineering and signal computation |
+| `ai_fundamental_screen` | Monthly (1st) | AI portfolio construction — scoring, selection, rebalancing |
+| `portfolio_performance` | Weekly (Friday) | Cumulative returns, Sharpe, max drawdown per strategy |
+| `news_analysis` | Monthly (26th) | AI bull/bear research reports per ticker |
+
+## Logs
+
+All job logs land in `logs/` (gitignored):
+
+| File | Job |
+|---|---|
+| `logs/daily_ingest.log` | Daily ingest |
+| `logs/weekly_performance.log` | Weekly performance |
+| `logs/monthly_strategy.log` | Monthly strategy |
+| `logs/monthly_news_analysis.log` | Monthly news analysis |
+| `logs/launchd.log` | launchd stdout/stderr |
+| `logs/run_manifest.jsonl` | Per-run OHLCV/news counts (used by report charts) |
+
+## Setup
+
+### Prerequisites
+
+- Python 3.13+, [uv](https://github.com/astral-sh/uv)
+- API keys: `ANTHROPIC_API_KEY`, `FINNHUB_API_KEY`
+- SMTP credentials for email reports: `RDD_SMTP_USER`, `RDD_SMTP_PASS`, `RDD_EMAIL_TO`
+
+### Install
+
+```bash
+# 1. Clone and install dependencies
+git clone <repo>
+cd rubber-duck-debugger
+uv sync
+
+# 2. Copy and fill in credentials
+cp .env.example .env   # edit with your keys
+
+# 3. Install launchd agents
+bash scripts/install_launchd.sh
+```
+
+### Development
+
+```bash
+# Run tests
+uv run pytest tests/
+
+# Lint / format
+uv run pre-commit run --files <changed files>
+
+# Run a pipeline manually
+uv run kedro run --pipeline stock_prices
+
+# Dry-run the daily ingest (prints commands, no execution)
+bash scripts/run_daily_ingest.sh --dry-run
+```
+
+Feature branches and experiments should be developed in a worktree to keep `main` clean:
+
+```bash
+# In Claude Code
+/worktree my-feature
+```

--- a/scripts/install_launchd.sh
+++ b/scripts/install_launchd.sh
@@ -2,9 +2,10 @@
 # Installs all RDD launchd agents. Idempotent — safe to run multiple times.
 #
 # Agents installed:
-#   com.rdd.daily-ingest      — Mon–Fri 10:00 local  (data ingestion)
-#   com.rdd.monthly-strategy  — 30th of each month 12:00 local  (claude_fundamental)
-#   com.rdd.weekly-performance — every Friday 12:00 local  (performance email)
+#   com.rdd.daily-ingest           — Mon–Fri 10:00 local  (data ingestion)
+#   com.rdd.weekly-performance     — every Friday 12:00 local  (performance email)
+#   com.rdd.monthly-strategy       — 1st of each month 12:00 local  (ai_fundamental_screen)
+#   com.rdd.monthly-news-analysis  — 26th of each month 12:00 local  (news analysis reports)
 
 set -euo pipefail
 
@@ -120,8 +121,39 @@ install_agent "com.rdd.weekly-performance" "$SCRIPT_DIR/run_weekly_performance.s
 </dict>
 </plist>"
 
+# ── 4. Monthly news analysis — 26th 12:00 ────────────────────────────────────
+
+install_agent "com.rdd.monthly-news-analysis" "$SCRIPT_DIR/run_monthly_news_analysis.sh" \
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+    <key>Label</key><string>com.rdd.monthly-news-analysis</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>$SCRIPT_DIR/run_monthly_news_analysis.sh</string>
+    </array>
+    <!-- 26th of each month at 12:00 local -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Day</key><integer>26</integer>
+        <key>Hour</key><integer>12</integer>
+        <key>Minute</key><integer>0</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key><string>/Users/Paul_Mora/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key><string>$HOME</string>
+    </dict>
+    <key>StandardOutPath</key><string>$LOG_DIR/monthly_news_analysis.log</string>
+    <key>StandardErrorPath</key><string>$LOG_DIR/monthly_news_analysis.log</string>
+</dict>
+</plist>"
+
 echo ""
 echo "All agents installed. Schedule summary:"
-echo "  Daily ingest    → Mon–Fri 10:00 local"
-echo "  Monthly strategy → 1st of each month 12:00 local"
-echo "  Weekly performance → every Friday 12:00 local"
+echo "  Daily ingest         → Mon–Fri 10:00 local"
+echo "  Monthly strategy     → 1st of each month 12:00 local"
+echo "  Weekly performance   → every Friday 12:00 local"
+echo "  Monthly news analysis → 26th of each month 12:00 local"

--- a/scripts/install_launchd.sh
+++ b/scripts/install_launchd.sh
@@ -5,7 +5,7 @@
 #   com.rdd.daily-ingest           — Mon–Fri 10:00 local  (data ingestion)
 #   com.rdd.weekly-performance     — every Friday 12:00 local  (performance email)
 #   com.rdd.monthly-strategy       — 1st of each month 12:00 local  (ai_fundamental_screen)
-#   com.rdd.monthly-news-analysis  — 26th of each month 12:00 local  (news analysis reports)
+#   com.rdd.weekly-news-analysis   — every Friday 12:00 local  (news analysis reports)
 
 set -euo pipefail
 
@@ -121,23 +121,23 @@ install_agent "com.rdd.weekly-performance" "$SCRIPT_DIR/run_weekly_performance.s
 </dict>
 </plist>"
 
-# ── 4. Monthly news analysis — 26th 12:00 ────────────────────────────────────
+# ── 4. Weekly news analysis — every Friday 12:00 ─────────────────────────────
 
-install_agent "com.rdd.monthly-news-analysis" "$SCRIPT_DIR/run_monthly_news_analysis.sh" \
+install_agent "com.rdd.weekly-news-analysis" "$SCRIPT_DIR/run_weekly_news_analysis.sh" \
 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
 <plist version=\"1.0\">
 <dict>
-    <key>Label</key><string>com.rdd.monthly-news-analysis</string>
+    <key>Label</key><string>com.rdd.weekly-news-analysis</string>
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>$SCRIPT_DIR/run_monthly_news_analysis.sh</string>
+        <string>$SCRIPT_DIR/run_weekly_news_analysis.sh</string>
     </array>
-    <!-- 26th of each month at 12:00 local -->
+    <!-- Every Friday at 12:00 local -->
     <key>StartCalendarInterval</key>
     <dict>
-        <key>Day</key><integer>26</integer>
+        <key>Weekday</key><integer>5</integer>
         <key>Hour</key><integer>12</integer>
         <key>Minute</key><integer>0</integer>
     </dict>
@@ -146,14 +146,14 @@ install_agent "com.rdd.monthly-news-analysis" "$SCRIPT_DIR/run_monthly_news_anal
         <key>PATH</key><string>/Users/Paul_Mora/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
         <key>HOME</key><string>$HOME</string>
     </dict>
-    <key>StandardOutPath</key><string>$LOG_DIR/monthly_news_analysis.log</string>
-    <key>StandardErrorPath</key><string>$LOG_DIR/monthly_news_analysis.log</string>
+    <key>StandardOutPath</key><string>$LOG_DIR/weekly_news_analysis.log</string>
+    <key>StandardErrorPath</key><string>$LOG_DIR/weekly_news_analysis.log</string>
 </dict>
 </plist>"
 
 echo ""
 echo "All agents installed. Schedule summary:"
-echo "  Daily ingest         → Mon–Fri 10:00 local"
-echo "  Monthly strategy     → 1st of each month 12:00 local"
-echo "  Weekly performance   → every Friday 12:00 local"
-echo "  Monthly news analysis → 26th of each month 12:00 local"
+echo "  Daily ingest        → Mon–Fri 10:00 local"
+echo "  Monthly strategy    → 1st of each month 12:00 local"
+echo "  Weekly performance  → every Friday 12:00 local"
+echo "  Weekly news analysis → every Friday 12:00 local"

--- a/scripts/run_monthly_news_analysis.sh
+++ b/scripts/run_monthly_news_analysis.sh
@@ -16,6 +16,22 @@ mkdir -p "$LOG_DIR"
 ts() { date -u "+%Y-%m-%dT%H:%M:%SZ"; }
 log() { echo "[$(ts)] $*" | tee -a "$LOG_FILE"; }
 
+_on_exit() {
+  local rc=$?
+  [[ $rc -eq 0 ]] && return
+  log "[ALERT] script failed (exit $rc) — sending failure alert..."
+  if [[ -f "$PROJECT_ROOT/.env" ]] && [[ -z "${RDD_SMTP_USER:-}" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/.env"
+    set +a
+  fi
+  (cd "$PROJECT_ROOT" && uv run python scripts/send_alert.py \
+    --subject "[RDD] run_monthly_news_analysis.sh FAILED (exit $rc)" \
+    --log "$LOG_FILE") >> "$LOG_FILE" 2>&1 || true
+}
+trap '_on_exit' EXIT
+
 main() {
   if [[ -f "$PROJECT_ROOT/.env" ]]; then
     set -a
@@ -26,8 +42,8 @@ main() {
 
   log "=== monthly news analysis start ==="
   git -C "$PROJECT_ROOT" fetch origin main >> "$LOG_FILE" 2>&1
-  git -C "$PROJECT_ROOT" checkout main >> "$LOG_FILE" 2>&1
-  git -C "$PROJECT_ROOT" pull --ff-only origin main >> "$LOG_FILE" 2>&1
+  git -C "$PROJECT_ROOT" checkout -f main >> "$LOG_FILE" 2>&1
+  git -C "$PROJECT_ROOT" reset --hard origin/main >> "$LOG_FILE" 2>&1
   log "[GIT] HEAD=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
 
   (cd "$PROJECT_ROOT" && uv run kedro run --pipeline news_analysis) >> "$LOG_FILE" 2>&1

--- a/scripts/run_weekly_news_analysis.sh
+++ b/scripts/run_weekly_news_analysis.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Runs the news_analysis pipeline once per month (scheduled for the 26th).
+# Runs the news_analysis pipeline every Friday at 12:00 local.
 # Sources .env and syncs to main before running.
 
 set -euo pipefail
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 LOG_DIR="$PROJECT_ROOT/logs"
-LOG_FILE="$LOG_DIR/monthly_news_analysis.log"
+LOG_FILE="$LOG_DIR/weekly_news_analysis.log"
 
 export PATH="/Users/Paul_Mora/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
@@ -27,7 +27,7 @@ _on_exit() {
     set +a
   fi
   (cd "$PROJECT_ROOT" && uv run python scripts/send_alert.py \
-    --subject "[RDD] run_monthly_news_analysis.sh FAILED (exit $rc)" \
+    --subject "[RDD] run_weekly_news_analysis.sh FAILED (exit $rc)" \
     --log "$LOG_FILE") >> "$LOG_FILE" 2>&1 || true
 }
 trap '_on_exit' EXIT
@@ -40,7 +40,7 @@ main() {
     set +a
   fi
 
-  log "=== monthly news analysis start ==="
+  log "=== weekly news analysis start ==="
   git -C "$PROJECT_ROOT" fetch origin main >> "$LOG_FILE" 2>&1
   git -C "$PROJECT_ROOT" checkout -f main >> "$LOG_FILE" 2>&1
   git -C "$PROJECT_ROOT" reset --hard origin/main >> "$LOG_FILE" 2>&1


### PR DESCRIPTION
…o launchd

- README.md: full project overview with automated job schedule table, pipeline catalogue, log file index, and setup instructions
- install_launchd.sh: add com.rdd.monthly-news-analysis agent (26th at 12:00 local), which was missing — the script existed but was never scheduled
- run_monthly_news_analysis.sh: apply checkout -f + reset --hard git sync pattern and EXIT trap failure alert (same fix as other scripts)

## Description

Brief summary of what this PR changes and why.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [ ] Self-review completed
- [ ] Tests added / updated
- [ ] `uv run pre-commit run --all-files` passes locally
- [ ] `uv run pytest` passes locally
- [ ] No data files committed (`data/`, `*.parquet`, `*.csv`)
- [ ] No secrets or API keys in code or config
