### PR TITLE
fix(report): exclude OHLCV-backfill zeros from news and company-info …

### DIFF
--- a/scripts/send_report.py
+++ b/scripts/send_report.py
@@ -329,7 +329,11 @@ def _make_chart(history: dict[date, dict], membership: dict[str, set[str]]) -> b
 def _make_company_info_chart(history: dict[date, dict], universe_size: int) -> bytes:
     """Render company info snapshot coverage over time as a PNG."""
     today = date.today()
-    dates = sorted(d for d in history if d <= today)
+    # Exclude OHLCV-backfill entries that have no company-info data (n_company_info == 0
+    # on those entries is a default, not a real observation).
+    dates = sorted(
+        d for d in history if d <= today and history[d].get("n_company_info", 0) > 0
+    )
     counts = [history[d].get("n_company_info", 0) for d in dates]
 
     fig, ax = plt.subplots(figsize=(10, 3))
@@ -368,7 +372,13 @@ def _make_company_info_chart(history: dict[date, dict], universe_size: int) -> b
 def _make_company_news_chart(history: dict[date, dict]) -> bytes:
     """Render company news coverage over time (tickers covered + cumulative articles)."""
     today = date.today()
-    dates = sorted(d for d in history if d <= today)
+    # Exclude OHLCV-backfill entries that have no news data (n_company_news_tickers == 0
+    # on those entries is a default, not a real observation).
+    dates = sorted(
+        d
+        for d in history
+        if d <= today and history[d].get("n_company_news_tickers", 0) > 0
+    )
     tickers = [history[d].get("n_company_news_tickers", 0) for d in dates]
     articles = [history[d].get("n_company_news_articles", 0) for d in dates]
 


### PR DESCRIPTION
…charts

_backfill_manifest creates manifest entries for dates inferred from OHLCV parquets, but defaults n_company_news_articles and n_company_info to 0. Plotting those zeros causes a false cliff-drop on any day where the cron failed. Filter to only dates with a real observation (count > 0).

## Description

Brief summary of what this PR changes and why.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [ ] Self-review completed
- [ ] Tests added / updated
- [ ] `uv run pre-commit run --all-files` passes locally
- [ ] `uv run pytest` passes locally
- [ ] No data files committed (`data/`, `*.parquet`, `*.csv`)
- [ ] No secrets or API keys in code or config
